### PR TITLE
Import old MarcoPolo settings

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleIconFile</key>
 	<string>cp-icon.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>au.id.symonds.MarcoPolo2</string>
+	<string>com.dustinrue.ControlPlane</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Import settings from MarcoPolo 2.x, we can now use the correct bundle identifier

fixes #16
