### PR TITLE
QuitApplicationAction crash

### DIFF
--- a/Source/QuitApplicationAction.m
+++ b/Source/QuitApplicationAction.m
@@ -55,14 +55,23 @@
 - (BOOL)execute:(NSString **)errorString
 {
 	// get bundle identifier
-	NSString *path = [[NSWorkspace sharedWorkspace] fullPathForApplication: application];
-	NSString *identifier = [[NSBundle bundleWithPath: path] bundleIdentifier];
+	NSString *path = [[NSWorkspace sharedWorkspace] fullPathForApplication:application];
+	NSString *identifier = [[NSBundle bundleWithPath:path] bundleIdentifier];
 	
 	// terminate
 	DSLog(@"Terminating all instances of application '%@'", identifier);
-	NSArray *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier: identifier];
-	[apps makeObjectsPerformSelector: @selector(terminate)];
-	
+    if (identifier.length > 0)
+    {
+        NSArray *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:identifier];
+        [apps makeObjectsPerformSelector:@selector(terminate)];
+	}
+    else
+    {
+        NSString *errorFormat = NSLocalizedString(@"Error terminating application '%@'.  Application not found.", @"");
+        *errorString = [NSString stringWithFormat:errorFormat, application];
+        return NO;
+    }
+    
 	return YES;
 }
 


### PR DESCRIPTION
I added some error handling to QuitApplicationAction to prevent a crash when Control Plane attempts to close a program that doesn't exist.
