### PR TITLE
Fix the issue with "false IP evidences" on non-octet-aligned netmasks

### DIFF
--- a/Source/IPEvidenceSource.m
+++ b/Source/IPEvidenceSource.m
@@ -321,6 +321,11 @@ static void ipChange(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info
             return YES;
     }
     
+    // we can calculate then which octet is actually interesting, the one we need to
+    // use to calculate additional information to help determine a match
+    int interesting_octet = ceil(prefix / 8);
+    int jump_size = prefix % 8; // distance between subnets
+    
     // based on the subnet mask, how many octets of the assigned IP address
     // and the rule IP must match?  This is based on the prefix.  Again, if dealing
     // with a simple class C network then the first 3 octets of the net mask would be
@@ -337,11 +342,6 @@ static void ipChange(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info
         if (![[ipExploded objectAtIndex:i] isEqualToString:[ruleIpExploded objectAtIndex:i]])
             return NO;
     }
-    
-    // we can calculate then which octet is actually interesting, the one we need to
-    // use to calculate additional information to help determine a match
-    int interesting_octet = ceil(prefix / 8);
-    int jump_size = prefix % 8; // distance between subnets
     
     // if we've made it this far and the "jump size" is 0, then the IP
     // fits within the range provided and we have a match.  This will happen


### PR DESCRIPTION
IP Evidence does not work correctly when the network mask is not aligned to an octet (8-bit) boundary. If the mask is for class A, B, or C, everything is fine. But when the network mask is, for example, 255.255.254.0, then ControlPlane will just check the first two octets of the IP address to match. And it won't check on the third octet though 7 bits of that octet do belong to the network ID according to the network mask. That gives false positives -- for example, IP address 192.168.1.33 will be considered as an evidence for a network defined by IP address 192.168.60.0 and network mask 255.255.254.0.

The root cause is as follows: In IPEvidenceSource.m, inside the isIP method, variables interesting_octet and jump_size are calculated based on the prefix value _after_ changing the value of prefix from the number of bits to the number of octets. That makes the calculated values of the former two variables invalid. They need to be initialized while the prefix value corresponds to for the number of bits set in the netmask, not octets.
