### PR TITLE
Quick optimization to checking IP Evidence rule matches

### DIFF
--- a/Source/IPEvidenceSource.m
+++ b/Source/IPEvidenceSource.m
@@ -227,7 +227,7 @@ static void ipChange(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info
 	NSEnumerator *en = [addresses objectEnumerator];
 	NSString *ip;
 
-	while ((ip = [en nextObject])) {
+	while ((ip = [en nextObject]) && !match) {
         if ([self isIp:ip inRuleIp:[comp objectAtIndex:0] withSubnetMask:[comp objectAtIndex:1]])
             match = YES;
 	}


### PR DESCRIPTION
As soon as a match is found, scanning all the remaining IP addresses is just wasting time
