### PR TITLE
Small optimization of rule matching loop

### DIFF
--- a/Source/EvidenceSource.m
+++ b/Source/EvidenceSource.m
@@ -542,14 +542,16 @@
 
 - (BOOL)ruleMatches:(NSDictionary *)rule
 {
-	NSEnumerator *en = [sources objectEnumerator];
+	NSString *ruleType = [rule objectForKey:@"type"];
+    NSEnumerator *en = [sources objectEnumerator];
 	EvidenceSource *src;
 	while ((src = [en nextObject])) {
+		if (![src matchesRulesOfType:ruleType])
+			continue;
+
         NSString *key = [NSString stringWithFormat:@"Enable%@EvidenceSource", [src name]];
 		BOOL enabled = [[NSUserDefaults standardUserDefaults] boolForKey:key];
 
-		if (![src matchesRulesOfType:[rule objectForKey:@"type"]])
-			continue;
 		if (enabled && [src isRunning] && [src doesRuleMatch:rule]) {
 #if DEBUG_MODE
             DSLog(@"checking EvidenceSource %@ for matching rules", src);


### PR DESCRIPTION
When looping though all the evidence sources, for a given rule, first check if the type of rule matches -- if it doesn't, then don't bother with the extra actions to get the value of "enabled". Also have the rule type string "preset" before doing the loop.
