### PR TITLE
Give more flexibility to subclasses of EvidenceSource with panel init

### DIFF
--- a/Source/EvidenceSource.h
+++ b/Source/EvidenceSource.h
@@ -24,6 +24,9 @@
 
 @property (readwrite) BOOL screenIsLocked;
 
++ (NSPanel *)getPanelFromNibNamed:(NSString *)name instantiatedWithOwner:(id)owner;
+
+- (id)initWithPanel:(NSPanel *)initPanel;
 - (id)initWithNibNamed:(NSString *)name;
 - (void)dealloc;
 - (void)goingToSleep:(id)arg;


### PR DESCRIPTION
When creating a subclass of EvidenceSource that implements several rules in it and each rule needs its own ("non-uniform") panel, the current interface does not allow to do it easy enough. (And, indeed, I need that flexibility now, for one of my implementations; work in progress.)

I propose to add initWithPanel: to class EvidenceSource. And also to add a ready class method for loading panels from nib files. With that addition, I will be happier as a developer of evidence sources...
