### PR TITLE
Retain panel outside getPanelFromNibNamed:instantiatedWithOwner:

### DIFF
--- a/Source/EvidenceSource.m
+++ b/Source/EvidenceSource.m
@@ -97,7 +97,7 @@
 	// Look for an NSPanel
     for (NSObject *obj in topLevelObjects) {
         if ([obj isKindOfClass:[NSPanel class]]) {
-            return (NSPanel *) [obj retain];
+            return (NSPanel *) obj;
         }
     }
 
@@ -111,7 +111,7 @@
         return nil;
     }
     
-    panel = [[self class] getPanelFromNibNamed:name instantiatedWithOwner:self];
+    panel = [[[self class] getPanelFromNibNamed:name instantiatedWithOwner:self] retain];
     if (!panel) {
         return nil;
     }


### PR DESCRIPTION
Minor correction to my earlier changes so that the returned panel object is retained (if required) in the external code, and not inside the class method itself.
