### PR TITLE
Handle Thunderbolt network adapters

### DIFF
--- a/Source/NetworkLinkEvidenceSource.h
+++ b/Source/NetworkLinkEvidenceSource.h
@@ -8,14 +8,7 @@
 #import "GenericEvidenceSource.h"
 
 
-@interface NetworkLinkEvidenceSource : GenericEvidenceSource {
-	NSLock *lock;
-	NSMutableArray *interfaces;
-
-	// For SystemConfiguration asynchronous notifications
-	SCDynamicStoreRef store;
-	CFRunLoopSourceRef runLoop;
-}
+@interface NetworkLinkEvidenceSource : GenericEvidenceSource
 
 - (id)init;
 - (void)dealloc;


### PR DESCRIPTION
You may be interested in some changes I've made to the NetworkLink evidence source.

The current version did not play well with Thunderbolt network adapters.

When a Thunderbolt Ethernet adapter is unplugged, the interface disappears completely, rather than signalling that link has gone inactive, as is the case with built-in network interfaces. ControlPlane therefore never noticed that such an interface was unplugged.

I have now changed the method of enumerating interfaces to get the Network Services; these are all the interfaces listed in the locations in System Preferences and persists even if the interface is not currently available. With this method, I get reliable context switching on plugging/unpluggging of Thunderbolt network adapters.

There are some other minor tweaks, such as using GCD for async notifications.
Hope this will be useful.
