### PR TITLE
Fix the leak of NSDate objects in DSLogger

### DIFF
--- a/Source/DSLogger.m
+++ b/Source/DSLogger.m
@@ -68,7 +68,8 @@ static DSLogger *shared_Logger = nil;
 	if (([now timeIntervalSinceDate:clusterStartDate] < clusterThreshold) && [lastFunction isEqualToString:function])
 		line = [NSString stringWithFormat:@"\t%@", proc];
 	else {
-		clusterStartDate = [now retain];
+		[clusterStartDate release];
+        clusterStartDate = [now retain];
 		line = [NSString stringWithFormat:@"%@ %@\n\t%@", [timestampFormatter stringFromDate:now], function, proc];
 	}
 	[lastFunction setString:function];


### PR DESCRIPTION
Release the current NSDate object referenced by clusterStartDate before assigning a new (retained) NSDate object to it.
