### PR TITLE
Switch to non-blocking implementation of DSLogger

### DIFF
--- a/Source/DSLogger.h
+++ b/Source/DSLogger.h
@@ -3,33 +3,24 @@
 //  ControlPlane
 //
 //  Created by David Symonds on 22/07/07.
+//  Modified by Vladimir Beloborodov on 01 Apr 2013.
 //
 
 
-@interface DSLogger : NSObject {
-	NSLock *lock;
-	NSDateFormatter *timestampFormatter;
+@interface DSLogger : NSObject
 
-	// Clustering
-	NSTimeInterval clusterThreshold;
-	NSDate *clusterStartDate;
-	NSMutableString *lastFunction;
-
-	// Ring buffer
-	NSMutableArray *buffer;
-	int startIndex, count;
-}
++ (void)initialize;
 
 + (DSLogger *)sharedLogger;
++ (void)logFromFunction:(NSString *)fnName withInfo:(NSString *)info;
 
 - (id)init;
 - (void)dealloc;
 
-- (void)logFromFunction:(NSString *)function withFormat:(NSString *)format, ...;
-
+- (void)logFromFunction:(NSString *)fnName withInfo:(NSString *)info;
 - (NSString *)buffer;
 
 #define DSLog(format, ...)	\
-	[[DSLogger sharedLogger] logFromFunction:[NSString stringWithUTF8String:__PRETTY_FUNCTION__] withFormat:(format),##__VA_ARGS__]
+	[DSLogger logFromFunction:[NSString stringWithUTF8String:__PRETTY_FUNCTION__] withInfo:[NSString stringWithFormat:(format),##__VA_ARGS__]]
 
 @end

--- a/Source/DSLogger.m
+++ b/Source/DSLogger.m
@@ -3,6 +3,7 @@
 //  ControlPlane
 //
 //  Created by David Symonds on 22/07/07.
+//  Modified by Vladimir Beloborodov on 01 Apr 2013.
 //
 
 #import "DSLogger.h"
@@ -10,26 +11,37 @@
 
 #define DSLOGGER_CAPACITY	128
 
-static DSLogger *shared_Logger = nil;
+static DSLogger *sharedLogger = nil;
 
+@implementation DSLogger {
+    dispatch_queue_t serialQueue;
 
-@implementation DSLogger
+	NSDateFormatter *timestampFormatter;
 
-+ (DSLogger *)sharedLogger
-{
-	if (!shared_Logger) {
-		shared_Logger = [[DSLogger alloc] init];
-	}
+	// Clustering
+	NSTimeInterval clusterThreshold;
+	NSDate *clusterStartDate;
+	NSString *lastFunction;
 
-	return shared_Logger;
+	// Ring buffer
+	NSMutableArray *buffer;
+	int startIndex, count;
 }
 
-- (id)init
-{
++ (void)initialize {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedLogger = [[self alloc] init];
+    });
+}
+
++ (DSLogger *)sharedLogger {
+	return sharedLogger;
+}
+
+- (id)init {
 	if (!(self = [super init]))
 		return nil;
-
-	lock = [[NSLock alloc] init];
 
 	timestampFormatter = [[NSDateFormatter alloc] init];
 	[timestampFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
@@ -37,78 +49,91 @@ static DSLogger *shared_Logger = nil;
 
 	clusterThreshold = 0.5;
 	clusterStartDate = [[NSDate distantPast] retain];
-	lastFunction = [[NSMutableString alloc] init];
+	lastFunction = [[NSString alloc] init];
 
 	buffer = [[NSMutableArray alloc] initWithCapacity:DSLOGGER_CAPACITY];
 	startIndex = count = 0;
 
+    serialQueue = dispatch_queue_create("ControlPlane.DSLogger", DISPATCH_QUEUE_SERIAL);
+
 	return self;
 }
 
-- (void)dealloc
-{
-	[lock release];
-	[timestampFormatter release];
-	[clusterStartDate release];
-	[lastFunction release];
-	[buffer release];
+- (void)dealloc {
+    dispatch_sync(serialQueue, ^{
+        [timestampFormatter release];
+        [clusterStartDate release];
+        [lastFunction release];
+        [buffer release];
+    });
+    dispatch_release(serialQueue);
 
 	[super dealloc];
 }
 
-- (void)logFromFunction:(NSString *)function withFormat:(NSString *)format, ...
-{
-	[lock lock];
+- (void)logFromFunction:(NSString *)fnName withInfo:(NSString *)info {
+    [[self class] logFromFunction:fnName withInfo:info];
+}
 
-	va_list ap;
-	va_start(ap, format);
-	NSDate *now = [NSDate date];
-	NSString *proc = [[[NSString alloc] initWithFormat:format arguments:ap] autorelease];
++ (void)logFromFunction:(NSString *)fnName withInfo:(NSString *)info {
+#ifdef DEBUG_MODE
+	NSLog(@"%@ %@", fnName, info);
+#endif
+
+    NSString *fnNameCopy = [fnName copy], *infoCopy = [info copy];
+	NSDate *now = [[NSDate alloc] init];
+    dispatch_async(sharedLogger->serialQueue, ^{
+        @autoreleasepool {
+            [sharedLogger doLogFromFunction:fnNameCopy withInfo:infoCopy timeStamp:now];
+        }
+        [now release];
+        [fnNameCopy release];
+        [infoCopy release];
+    });
+}
+
+- (void)doLogFromFunction:(NSString *)func withInfo:(NSString *)info timeStamp:(NSDate *)timeSt {
 	NSString *line;
-	if (([now timeIntervalSinceDate:clusterStartDate] < clusterThreshold) && [lastFunction isEqualToString:function])
-		line = [NSString stringWithFormat:@"\t%@", proc];
+
+	if (([timeSt timeIntervalSinceDate:clusterStartDate] < clusterThreshold) && [lastFunction isEqualToString:func])
+		line = [@"\t" stringByAppendingString:info];
 	else {
 		[clusterStartDate release];
-        clusterStartDate = [now retain];
-		line = [NSString stringWithFormat:@"%@ %@\n\t%@", [timestampFormatter stringFromDate:now], function, proc];
+        clusterStartDate = [timeSt retain];
+        
+        [lastFunction release];
+        lastFunction = [func retain];
+        
+		line = [NSString stringWithFormat:@"%@ %@\n\t%@", [timestampFormatter stringFromDate:timeSt], func, info];
 	}
-	[lastFunction setString:function];
-	va_end(ap);
-#ifdef DEBUG_MODE
-	NSLog(@"%@ %@", function, proc);
-#endif
 
 	if (count < DSLOGGER_CAPACITY) {
 		[buffer addObject:line];
 		++count;
 	} else {
-		[buffer replaceObjectAtIndex:startIndex withObject:line];
-		startIndex = (startIndex + 1) % DSLOGGER_CAPACITY;
+		buffer[startIndex] = line;
+        ++startIndex;
+        startIndex %= DSLOGGER_CAPACITY;
 	}
-
-	[lock unlock];
 }
 
-// XXX: horribly inefficient!
-- (NSString *)buffer
-{
-	if (count == 0)
-		return @"";
-
-	[lock lock];
+- (NSString *)buffer {
 	NSMutableString *buf = [NSMutableString string];
+
+    dispatch_suspend(serialQueue);
 	int i = startIndex, cnt = count;
 
 	while (cnt > 0) {
-		[buf appendString:[buffer objectAtIndex:i]];
+		[buf appendString:buffer[i]];
 		if (cnt > 1)
 			[buf appendString:@"\n"];
 
-		i = (i + 1) % DSLOGGER_CAPACITY;
+        ++i;
+        i %= DSLOGGER_CAPACITY;
 		--cnt;
 	}
 
-	[lock unlock];
+    dispatch_resume(serialQueue);
 	return buf;
 }
 


### PR DESCRIPTION
Hi Dustin, -- I hope I haven't overwhelmed you with my recent requests...

With these changes I propose a new, non-blocking (lock-free) implementation of **DSLogger** -- the implementation is based on the great GCD mechanism. With this approach, the threads calling **DSLog** are never blocked -- even if some other threads call it too and even if the whole buffer content is being prepared at the very same moment. Testing it for a few days, there is definitely no performance degradation (at least).
