### PR TITLE
Minor improvement to better handle "non-app" bundles in OpenAction

### DIFF
--- a/Source/OpenAction.m
+++ b/Source/OpenAction.m
@@ -83,15 +83,15 @@
         // they are either specifying that an actual file (not an app) be
         // opened
         if (requestedAppBundle != nil) {
-            NSString *requestedApplBundleIdentifier = [requestedAppBundle bundleIdentifier];
+            NSString *bundleId = [requestedAppBundle bundleIdentifier];
             @try {
-                if ([[NSRunningApplication runningApplicationsWithBundleIdentifier:requestedApplBundleIdentifier] count] > 0) {
-                    DSLog(@"%@ is already running", requestedApplBundleIdentifier);
+                if (bundleId && [[NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId] count]) {
+                    DSLog(@"%@ is already running", bundleId);
                     return YES;
                 }
             }
             @catch (NSException * e) {
-                DSLog(@"failed to get the bundleidentifier for %@", requestedApplBundleIdentifier);
+                DSLog(@"failed to get the bundleidentifier for %@", bundleId);
             }
         }
 


### PR DESCRIPTION
Some applications utilize bundles as "containers" for their document formats. Such custom bundles often don't have info.plist in them. When these "non-app" bundle files are to be opened (as documents) by corresponding apps with OpenAction, **bundleIdentifier** returns nil (as no info.plist provided). While it cannot affect ControlPlane thanks to the try / catch block around the call of **runningApplicationsWithBundleIdentifier**, that method adds an internal assert message to the log. Let's add an extra "safety" check here.
