### PR TITLE
Minor refactoring of CPController (variable guessConfidence is redundant)

### DIFF
--- a/Source/CPController.h
+++ b/Source/CPController.h
@@ -18,7 +18,6 @@
 	NSTimer *sbHideTimer;
 
 	NSString *currentContextUUID, *currentContextName;
-	NSString *guessConfidence;
 	BOOL guessIsConfident;
 	NSInteger smoothCounter;
 


### PR DESCRIPTION
Instance variable **guessConfidence** in **CPController** is only used to pass the confidence message string into **performTransitionFrom:to:** . It is more clear and straightforward to just pass that value as an extra parameter of the method.

Also, the guess' parameters (UUID and confidence value) returned from **getMostConfidentContext:** are now passed using **NSArray** -- the manipulations required to extract those two parameters from **NSDictionary** are an overkill.
