### PR TITLE
Use dispatch_release to release GCD queue in NetworkLinkEvidenceSource

### DIFF
--- a/Source/NetworkLinkEvidenceSource.m
+++ b/Source/NetworkLinkEvidenceSource.m
@@ -114,14 +114,9 @@ static void linkChange(SCDynamicStoreRef store, CFArrayRef changedKeys,  void *i
 		return;
 
 	// Register for asynchronous notifications
-	SCDynamicStoreContext ctxt;
-	ctxt.version = 0;
-	ctxt.info = self;
-	ctxt.retain = NULL;
-	ctxt.release = NULL;
-	ctxt.copyDescription = NULL;
-
+	SCDynamicStoreContext ctxt = {0, self, NULL, NULL, NULL}; // {version, info, retain, release, copyDescription}
 	store = SCDynamicStoreCreate(NULL, CFSTR("ControlPlane"), linkChange, &ctxt);
+
     dispatch_queue_t queue = dispatch_queue_create("ControlPlane.NetworkLink", NULL);
     SCDynamicStoreSetDispatchQueue(store, queue);
 
@@ -141,7 +136,7 @@ static void linkChange(SCDynamicStoreRef store, CFArrayRef changedKeys,  void *i
         [self doFullUpdate:nil];
     });
 
-    CFRelease(queue); // retained by 'store'
+    dispatch_release(queue); // retained by 'store'
 
     didSleep = NO;
 	running = YES;


### PR DESCRIPTION
Just a small correction triggered by today's report #246 and my follow-up scan of the related code: While using **CFRelease** on a GCD queue (created with **dispatch_queue_create**) may possibly work as expected -- as least, it did not cause any notable problems on my system and (I assume) on quite a few other systems, for a while. But Apple officially and explicitly requests to use **dispatch_release** to decrement the reference count of any dispatch object, including the GCD queue. Thus let's do it that way.

The info provided with #246 so far was not sufficient for me to find (or make a good guess on -- and then dupe) the actual root cause of that issue. Thus I would not stick my neck out to state that it will be eliminated with this change. But, at least, the change won't make things worse. :)  [That said, interestingly, the crash reported did somehow happen when calling **CFRelease** on the queue.]
