### PR TITLE
Major improvements to the code controlling the menu bar

### DIFF
--- a/Source/CPController.h
+++ b/Source/CPController.h
@@ -18,7 +18,6 @@
 	NSTimer *sbHideTimer;
 
 	NSString *currentContextUUID, *currentContextName;
-	BOOL guessIsConfident;
 	NSInteger smoothCounter;
 
 	IBOutlet NSMenuItem *forceContextMenuItem;
@@ -28,7 +27,6 @@
 	NSTimer *updatingTimer;
 	NSThread *updatingThread;
 	NSLock *updatingSwitchingLock;
-    NSLock *menuBarLocker;
 	NSConditionLock *updatingLock;
 	BOOL timeToDie;
 


### PR DESCRIPTION
This bunch of changes in **CPController** make the code controlling all the changes to the menu bar (i.e. to the icon and/or title shown) more consistent, easier to read and maintain, and notably quicker. The main changes are:
- Changes to menu bar are now only done where the changes to the related data happen in the code: Application start or restart, setting new a active context, changes to the list of contexts or changes to default preferences. In addition to the code structure improvements, it allows to reduce the CPU load during the "no-change monitoring cycle" of CP significantly lower.
- All the changes to the menu bar are now done on the main tread. That allows to eliminate any need in a lock when doing those change. Plus it better "fits" Apple's recommendations to do "GUI updates" on a single thread (preferably on the main one).
- Changes that the user makes to the icon preference setting (icon, context, or both) will now get effective immediately -- looks nicer! :)

There also a few code other minor cleanups and improvements.

I am asking other team members (who can build from the source code on their own) to try the updated CP on their systems and see how it goes for them.

[There will be a few more optimizations submitted over the next few days. Shorter than this one. Stay tuned! :)  ]
