### PR TITLE
Instantiate nib using the recommended method in OS X 10.8+

### DIFF
--- a/Source/EvidenceSource.m
+++ b/Source/EvidenceSource.m
@@ -89,10 +89,17 @@
 	}
 
 	NSArray *topLevelObjects = nil;
-	if (![nib instantiateNibWithOwner:owner topLevelObjects:&topLevelObjects]) {
-		NSLog(@"%@ >> failed instantiating nib (named '%@')!", [self class], name);
-		return nil;
-	}
+    if ([nib respondsToSelector:@selector(instantiateWithOwner:topLevelObjects:)]) {
+        if (![nib instantiateWithOwner:owner topLevelObjects:&topLevelObjects]) {
+            NSLog(@"%@ >> failed instantiating nib (named '%@')!", [self class], name);
+            return nil;
+        }
+    } else {
+        if (![nib instantiateNibWithOwner:owner topLevelObjects:&topLevelObjects]) {
+            NSLog(@"%@ >> failed instantiating nib (named '%@')!", [self class], name);
+            return nil;
+        }
+    }
     
 	// Look for an NSPanel
     for (NSObject *obj in topLevelObjects) {


### PR DESCRIPTION
Use recommended method **instantiateWithOwner:topLevelObjects:** in OS X 10.8 and later. For older versions still use the now-deprecated **instantiateNibWithOwner:topLevelObjects:**. (See Apple's developer documentation on **NSNib** for more details.)
