### PR TITLE
Enhancement: Show which rules match (in Preferences/Rules)

### DIFF
--- a/Resources/da-DK.lproj/MainMenu.xib
+++ b/Resources/da-DK.lproj/MainMenu.xib
@@ -769,7 +769,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="982186366"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="781215745"/>
+										<reference key="NSNextKeyView" ref="1007950745"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -788,6 +788,50 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
+											<object class="NSTableColumn" id="908836847">
+												<double key="NSWidth">12</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">✓</string>
+													<object class="NSFont" key="NSSupport" id="26">
+														<string key="NSName">LucidaGrande</string>
+														<double key="NSSize">11</double>
+														<int key="NSfFlags">3100</int>
+													</object>
+													<object class="NSColor" key="NSBackgroundColor" id="252361990">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="613744654"/>
+													</object>
+													<object class="NSColor" key="NSTextColor" id="827448603">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerTextColor</string>
+														<reference key="NSColor" ref="956183839"/>
+													</object>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="672003038">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
+													<reference key="NSSupport" ref="736811615"/>
+													<reference key="NSControlView" ref="914064272"/>
+													<object class="NSColor" key="NSBackgroundColor" id="851406511">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">controlBackgroundColor</string>
+														<reference key="NSColor" ref="657369262"/>
+													</object>
+													<reference key="NSTextColor" ref="468606996"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="914064272"/>
+											</object>
 											<object class="NSTableColumn" id="221996602">
 												<string key="NSIdentifier">type</string>
 												<double key="NSWidth">57</double>
@@ -797,33 +841,19 @@
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Type</string>
-													<object class="NSFont" key="NSSupport" id="26">
-														<string key="NSName">LucidaGrande</string>
-														<double key="NSSize">11</double>
-														<int key="NSfFlags">3100</int>
-													</object>
+													<reference key="NSSupport" ref="26"/>
 													<object class="NSColor" key="NSBackgroundColor" id="577799439">
 														<int key="NSColorSpace">3</int>
 														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
 													</object>
-													<object class="NSColor" key="NSTextColor" id="827448603">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerTextColor</string>
-														<reference key="NSColor" ref="956183839"/>
-													</object>
+													<reference key="NSTextColor" ref="827448603"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="81149509">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
 													<reference key="NSSupport" ref="736811615"/>
 													<reference key="NSControlView" ref="914064272"/>
-													<object class="NSColor" key="NSBackgroundColor" id="851406511">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlBackgroundColor</string>
-														<reference key="NSColor" ref="657369262"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="851406511"/>
 													<reference key="NSTextColor" ref="468606996"/>
 												</object>
 												<int key="NSResizingMask">3</int>
@@ -866,12 +896,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Kontekst</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="252361990">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="613744654"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="252361990"/>
 													<reference key="NSTextColor" ref="827448603"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="724373708">
@@ -965,15 +990,15 @@
 							<object class="NSScroller" id="1007950745">
 								<reference key="NSNextResponder" ref="265930281"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="265930281"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="651013189"/>
+								<reference key="NSNextKeyView" ref="781215745"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="265930281"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.99770642201834858</double>
 							</object>
 							<object class="NSClipView" id="651013189">
 								<reference key="NSNextResponder" ref="265930281"/>
@@ -993,7 +1018,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="764886370"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="1007950745"/>
+						<reference key="NSNextKeyView" ref="651013189"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="496414959"/>
 						<reference key="NSHScroller" ref="1007950745"/>
@@ -1068,7 +1093,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="764886370"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="700875448">
 							<int key="NSCellFlags">67108864</int>
@@ -4994,6 +5018,26 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 					</object>
 					<int key="connectionID">1920</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="908836847"/>
+						<reference key="destination" ref="975999155"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="908836847"/>
+							<reference key="NSDestination" ref="975999155"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1927</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5278,6 +5322,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 							<reference ref="717826431"/>
 							<reference ref="81609201"/>
 							<reference ref="1066837865"/>
+							<reference ref="908836847"/>
 						</array>
 						<reference key="parent" ref="265930281"/>
 					</object>
@@ -6885,6 +6930,19 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<reference key="object" ref="779012452"/>
 						<reference key="parent" ref="907453669"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1923</int>
+						<reference key="object" ref="908836847"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="672003038"/>
+						</array>
+						<reference key="parent" ref="914064272"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1924</int>
+						<reference key="object" ref="672003038"/>
+						<reference key="parent" ref="908836847"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7172,6 +7230,8 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 				</object>
 				<string key="1916.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1917.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1923.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1924.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7217,7 +7277,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1922</int>
+			<int key="maxID">1927</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/de.lproj/MainMenu.xib
+++ b/Resources/de.lproj/MainMenu.xib
@@ -760,17 +760,17 @@
 									<object class="NSTableView" id="346015909">
 										<reference key="NSNextResponder" ref="136212862"/>
 										<int key="NSvFlags">256</int>
-										<string key="NSFrameSize">{435, 198}</string>
+										<string key="NSFrameSize">{438, 198}</string>
 										<reference key="NSSuperview" ref="136212862"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="510320836"/>
+										<reference key="NSNextKeyView" ref="215464208"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
 										<object class="NSTableHeaderView" key="NSHeaderView" id="554022231">
 											<reference key="NSNextResponder" ref="44901239"/>
 											<int key="NSvFlags">256</int>
-											<string key="NSFrameSize">{435, 17}</string>
+											<string key="NSFrameSize">{438, 17}</string>
 											<reference key="NSSuperview" ref="44901239"/>
 											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="662548180"/>
@@ -783,23 +783,24 @@
 										</object>
 										<object class="NSMutableArray" key="NSTableColumns">
 											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSTableColumn" id="870504985">
-												<string key="NSIdentifier">type</string>
-												<double key="NSWidth">57</double>
-												<double key="NSMinWidth">40</double>
-												<double key="NSMaxWidth">1000</double>
+											<object class="NSTableColumn" id="399410271">
+												<double key="NSWidth">12</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
-													<string key="NSContents">Typ</string>
+													<string key="NSContents">✓</string>
 													<object class="NSFont" key="NSSupport" id="26">
 														<string key="NSName">LucidaGrande</string>
 														<double key="NSSize">11</double>
 														<int key="NSfFlags">3100</int>
 													</object>
-													<object class="NSColor" key="NSBackgroundColor" id="950024977">
-														<int key="NSColorSpace">3</int>
-														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													<object class="NSColor" key="NSBackgroundColor" id="700746904">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="866540352"/>
 													</object>
 													<object class="NSColor" key="NSTextColor" id="574458799">
 														<int key="NSColorSpace">6</int>
@@ -808,9 +809,10 @@
 														<reference key="NSColor" ref="696835979"/>
 													</object>
 												</object>
-												<object class="NSTextFieldCell" key="NSDataCell" id="1059274622">
+												<object class="NSTextFieldCell" key="NSDataCell" id="734851514">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
 													<reference key="NSSupport" ref="595299968"/>
 													<reference key="NSControlView" ref="346015909"/>
 													<object class="NSColor" key="NSBackgroundColor" id="84122985">
@@ -825,9 +827,37 @@
 												<bool key="NSIsResizeable">YES</bool>
 												<reference key="NSTableView" ref="346015909"/>
 											</object>
+											<object class="NSTableColumn" id="870504985">
+												<string key="NSIdentifier">type</string>
+												<double key="NSWidth">59</double>
+												<double key="NSMinWidth">40</double>
+												<double key="NSMaxWidth">1000</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Typ</string>
+													<reference key="NSSupport" ref="26"/>
+													<object class="NSColor" key="NSBackgroundColor" id="950024977">
+														<int key="NSColorSpace">3</int>
+														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													</object>
+													<reference key="NSTextColor" ref="574458799"/>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="1059274622">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<reference key="NSSupport" ref="595299968"/>
+													<reference key="NSControlView" ref="346015909"/>
+													<reference key="NSBackgroundColor" ref="84122985"/>
+													<reference key="NSTextColor" ref="1013935801"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="346015909"/>
+											</object>
 											<object class="NSTableColumn" id="803603226">
 												<string key="NSIdentifier">description</string>
-												<double key="NSWidth">141.8720703125</double>
+												<double key="NSWidth">142.8720703125</double>
 												<double key="NSMinWidth">40</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -861,12 +891,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Umgebung</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="700746904">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="866540352"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="700746904"/>
 													<reference key="NSTextColor" ref="574458799"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="762048385">
@@ -937,7 +962,7 @@
 										<int key="NSTableViewGroupRowStyle">1</int>
 									</object>
 								</object>
-								<string key="NSFrame">{{1, 17}, {435, 198}}</string>
+								<string key="NSFrame">{{1, 17}, {438, 198}}</string>
 								<reference key="NSSuperview" ref="874464119"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="346015909"/>
@@ -960,15 +985,15 @@
 							<object class="NSScroller" id="215464208">
 								<reference key="NSNextResponder" ref="874464119"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="874464119"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="44901239"/>
+								<reference key="NSNextKeyView" ref="510320836"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="874464119"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.99542334096109841</double>
 							</object>
 							<object class="NSClipView" id="44901239">
 								<reference key="NSNextResponder" ref="874464119"/>
@@ -977,7 +1002,7 @@
 									<bool key="EncodedWithXMLCoder">YES</bool>
 									<reference ref="554022231"/>
 								</object>
-								<string key="NSFrame">{{1, 0}, {435, 17}}</string>
+								<string key="NSFrame">{{1, 0}, {438, 17}}</string>
 								<reference key="NSSuperview" ref="874464119"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="554022231"/>
@@ -986,10 +1011,10 @@
 								<int key="NScvFlags">4</int>
 							</object>
 						</object>
-						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
+						<string key="NSFrame">{{20, 48}, {440, 216}}</string>
 						<reference key="NSSuperview" ref="889027356"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="215464208"/>
+						<reference key="NSNextKeyView" ref="44901239"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="662548180"/>
 						<reference key="NSHScroller" ref="215464208"/>
@@ -1064,7 +1089,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="889027356"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="221425782">
 							<int key="NSCellFlags">67108864</int>
@@ -1088,7 +1112,7 @@
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</object>
-				<string key="NSFrameSize">{477, 284}</string>
+				<string key="NSFrameSize">{480, 284}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="874464119"/>
@@ -5137,6 +5161,26 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					</object>
 					<int key="connectionID">1943</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="399410271"/>
+						<reference key="destination" ref="827118435"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="399410271"/>
+							<reference key="NSDestination" ref="827118435"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1950</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -5441,6 +5485,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<reference ref="44500243"/>
 							<reference ref="803603226"/>
 							<reference ref="12517043"/>
+							<reference ref="399410271"/>
 						</object>
 						<reference key="parent" ref="874464119"/>
 					</object>
@@ -7134,6 +7179,20 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<reference key="object" ref="349850955"/>
 						<reference key="parent" ref="587368537"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1946</int>
+						<reference key="object" ref="399410271"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="734851514"/>
+						</object>
+						<reference key="parent" ref="346015909"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1947</int>
+						<reference key="object" ref="734851514"/>
+						<reference key="parent" ref="399410271"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -7408,6 +7467,8 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					<string>1938.IBAttributePlaceholdersKey</string>
 					<string>1938.IBPluginDependency</string>
 					<string>1939.IBPluginDependency</string>
+					<string>1946.IBPluginDependency</string>
+					<string>1947.IBPluginDependency</string>
 					<string>231.CustomClassName</string>
 					<string>231.IBPluginDependency</string>
 					<string>288.IBPluginDependency</string>
@@ -7733,6 +7794,8 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					</object>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>DNDArrayController</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7787,7 +7850,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">1945</int>
+			<int key="maxID">1950</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -759,17 +759,17 @@
 									<object class="NSTableView" id="429936463">
 										<reference key="NSNextResponder" ref="916458113"/>
 										<int key="NSvFlags">256</int>
-										<string key="NSFrameSize">{435, 198}</string>
+										<string key="NSFrameSize">{452, 198}</string>
 										<reference key="NSSuperview" ref="916458113"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="829084382"/>
+										<reference key="NSNextKeyView" ref="729802760"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
 										<object class="NSTableHeaderView" key="NSHeaderView" id="246826205">
 											<reference key="NSNextResponder" ref="217639070"/>
 											<int key="NSvFlags">256</int>
-											<string key="NSFrameSize">{435, 17}</string>
+											<string key="NSFrameSize">{452, 17}</string>
 											<reference key="NSSuperview" ref="217639070"/>
 											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="439280017"/>
@@ -781,23 +781,25 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
-											<object class="NSTableColumn" id="680444923">
-												<string key="NSIdentifier">type</string>
-												<double key="NSWidth">57</double>
-												<double key="NSMinWidth">40</double>
-												<double key="NSMaxWidth">1000</double>
+											<object class="NSTableColumn" id="348936883">
+												<string key="NSIdentifier">status</string>
+												<double key="NSWidth">15</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
-													<string key="NSContents">Type</string>
+													<string key="NSContents">✓</string>
 													<object class="NSFont" key="NSSupport" id="26">
 														<string key="NSName">LucidaGrande</string>
 														<double key="NSSize">11</double>
 														<int key="NSfFlags">3100</int>
 													</object>
-													<object class="NSColor" key="NSBackgroundColor" id="808439282">
-														<int key="NSColorSpace">3</int>
-														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													<object class="NSColor" key="NSBackgroundColor" id="652195632">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="326007814"/>
 													</object>
 													<object class="NSColor" key="NSTextColor" id="932037218">
 														<int key="NSColorSpace">6</int>
@@ -806,9 +808,10 @@
 														<reference key="NSColor" ref="43650902"/>
 													</object>
 												</object>
-												<object class="NSTextFieldCell" key="NSDataCell" id="629124962">
+												<object class="NSTextFieldCell" key="NSDataCell" id="216659969">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
 													<reference key="NSSupport" ref="677502429"/>
 													<reference key="NSControlView" ref="429936463"/>
 													<object class="NSColor" key="NSBackgroundColor" id="537404427">
@@ -823,9 +826,37 @@
 												<bool key="NSIsResizeable">YES</bool>
 												<reference key="NSTableView" ref="429936463"/>
 											</object>
+											<object class="NSTableColumn" id="680444923">
+												<string key="NSIdentifier">type</string>
+												<double key="NSWidth">60</double>
+												<double key="NSMinWidth">40</double>
+												<double key="NSMaxWidth">1000</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Type</string>
+													<reference key="NSSupport" ref="26"/>
+													<object class="NSColor" key="NSBackgroundColor" id="808439282">
+														<int key="NSColorSpace">3</int>
+														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													</object>
+													<reference key="NSTextColor" ref="932037218"/>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="629124962">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<reference key="NSSupport" ref="677502429"/>
+													<reference key="NSControlView" ref="429936463"/>
+													<reference key="NSBackgroundColor" ref="537404427"/>
+													<reference key="NSTextColor" ref="249372474"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="429936463"/>
+											</object>
 											<object class="NSTableColumn" id="683956143">
 												<string key="NSIdentifier">description</string>
-												<double key="NSWidth">141.8720703125</double>
+												<double key="NSWidth">142.8720703125</double>
 												<double key="NSMinWidth">40</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -851,7 +882,7 @@
 											</object>
 											<object class="NSTableColumn" id="886118329">
 												<string key="NSIdentifier">location</string>
-												<double key="NSWidth">82.20263671875</double>
+												<double key="NSWidth">79.20263671875</double>
 												<double key="NSMinWidth">10</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -859,12 +890,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Context</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="652195632">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="326007814"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="652195632"/>
 													<reference key="NSTextColor" ref="932037218"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="552367397">
@@ -881,7 +907,7 @@
 											</object>
 											<object class="NSTableColumn" id="639626398">
 												<string key="NSIdentifier">confidence</string>
-												<double key="NSWidth">126.92529296875</double>
+												<double key="NSWidth">130.92529296875</double>
 												<double key="NSMinWidth">63.92529296875</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -935,7 +961,7 @@
 										<int key="NSTableViewGroupRowStyle">1</int>
 									</object>
 								</array>
-								<string key="NSFrame">{{1, 17}, {435, 198}}</string>
+								<string key="NSFrame">{{1, 17}, {452, 198}}</string>
 								<reference key="NSSuperview" ref="490514779"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="429936463"/>
@@ -958,15 +984,15 @@
 							<object class="NSScroller" id="729802760">
 								<reference key="NSNextResponder" ref="490514779"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="490514779"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="217639070"/>
+								<reference key="NSNextKeyView" ref="829084382"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="490514779"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.97752808988764039</double>
 							</object>
 							<object class="NSClipView" id="217639070">
 								<reference key="NSNextResponder" ref="490514779"/>
@@ -974,7 +1000,7 @@
 								<array class="NSMutableArray" key="NSSubviews">
 									<reference ref="246826205"/>
 								</array>
-								<string key="NSFrame">{{1, 0}, {435, 17}}</string>
+								<string key="NSFrame">{{1, 0}, {452, 17}}</string>
 								<reference key="NSSuperview" ref="490514779"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="246826205"/>
@@ -983,10 +1009,10 @@
 								<int key="NScvFlags">4</int>
 							</object>
 						</array>
-						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
+						<string key="NSFrame">{{20, 48}, {454, 216}}</string>
 						<reference key="NSSuperview" ref="273226987"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="729802760"/>
+						<reference key="NSNextKeyView" ref="217639070"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="439280017"/>
 						<reference key="NSHScroller" ref="729802760"/>
@@ -1085,7 +1111,7 @@
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</array>
-				<string key="NSFrameSize">{477, 284}</string>
+				<string key="NSFrameSize">{494, 284}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="490514779"/>
@@ -3541,26 +3567,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1833</int>
 				</object>
 				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentArray: values.Rules</string>
-						<reference key="source" ref="736607620"/>
-						<reference key="destination" ref="1020212776"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="736607620"/>
-							<reference key="NSDestination" ref="1020212776"/>
-							<string key="NSLabel">contentArray: values.Rules</string>
-							<string key="NSBinding">contentArray</string>
-							<string key="NSKeyPath">values.Rules</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSHandlesContentAsCompoundValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">306</int>
-				</object>
-				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
 						<string key="label">remove:</string>
 						<reference key="source" ref="736607620"/>
@@ -3575,6 +3581,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="destination" ref="429936463"/>
 					</object>
 					<int key="connectionID">1554</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">contentArray: activeRules</string>
+						<reference key="source" ref="736607620"/>
+						<reference key="destination" ref="861962292"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="736607620"/>
+							<reference key="NSDestination" ref="861962292"/>
+							<string key="NSLabel">contentArray: activeRules</string>
+							<string key="NSBinding">contentArray</string>
+							<string key="NSKeyPath">activeRules</string>
+							<dictionary key="NSOptions">
+								<boolean value="NO" key="NSConditionallySetsEditable"/>
+								<boolean value="YES" key="NSHandlesContentAsCompoundValue"/>
+							</dictionary>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">2104</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -4055,14 +4081,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<string key="NSLabel">value: arrangedObjects.type</string>
 							<string key="NSBinding">value</string>
 							<string key="NSKeyPath">arrangedObjects.type</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSConditionallySetsEditable</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
+							<dictionary key="NSOptions">
+								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
+								<boolean value="YES" key="NSConditionallySetsEditable"/>
+							</dictionary>
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">984</int>
+					<int key="connectionID">2075</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -4075,10 +4101,15 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<string key="NSLabel">value: arrangedObjects.confidence</string>
 							<string key="NSBinding">value</string>
 							<string key="NSKeyPath">arrangedObjects.confidence</string>
+							<dictionary key="NSOptions">
+								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
+								<boolean value="YES" key="NSConditionallySetsEditable"/>
+								<boolean value="NO" key="NSConditionallySetsEnabled"/>
+							</dictionary>
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">990</int>
+					<int key="connectionID">2103</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -4091,10 +4122,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<string key="NSLabel">value: arrangedObjects.description</string>
 							<string key="NSBinding">value</string>
 							<string key="NSKeyPath">arrangedObjects.description</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">986</int>
+					<int key="connectionID">2074</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -4108,13 +4143,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<string key="NSBinding">value</string>
 							<string key="NSKeyPath">arrangedObjects.context</string>
 							<dictionary key="NSOptions">
+								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
 								<boolean value="YES" key="NSConditionallySetsEditable"/>
 								<string key="NSValueTransformerName">ContextNameTransformer</string>
 							</dictionary>
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">1695</int>
+					<int key="connectionID">2101</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -4966,6 +5002,27 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 					<int key="connectionID">2052</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="348936883"/>
+						<reference key="destination" ref="736607620"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="348936883"/>
+							<reference key="NSDestination" ref="736607620"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<dictionary key="NSOptions">
+								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
+								<boolean value="YES" key="NSConditionallySetsEditable"/>
+								<string key="NSValueTransformerName">RuleStatusResultTransformer</string>
+							</dictionary>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">2096</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5242,6 +5299,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="639626398"/>
 							<reference ref="683956143"/>
 							<reference ref="886118329"/>
+							<reference ref="348936883"/>
 						</array>
 						<reference key="parent" ref="490514779"/>
 					</object>
@@ -6857,6 +6915,19 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="545498138"/>
 						<reference key="parent" ref="367410236"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2059</int>
+						<reference key="object" ref="348936883"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="216659969"/>
+						</array>
+						<reference key="parent" ref="429936463"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2060</int>
+						<reference key="object" ref="216659969"/>
+						<reference key="parent" ref="348936883"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7141,6 +7212,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				</object>
 				<string key="2048.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2049.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2059.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2060.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7199,7 +7272,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">2058</int>
+			<int key="maxID">2104</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/fr.lproj/MainMenu.xib
+++ b/Resources/fr.lproj/MainMenu.xib
@@ -765,17 +765,17 @@
 									<object class="NSTableView" id="1057557008">
 										<reference key="NSNextResponder" ref="636682733"/>
 										<int key="NSvFlags">256</int>
-										<string key="NSFrameSize">{435, 198}</string>
+										<string key="NSFrameSize">{436, 198}</string>
 										<reference key="NSSuperview" ref="636682733"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="716182453"/>
+										<reference key="NSNextKeyView" ref="592256119"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
 										<object class="NSTableHeaderView" key="NSHeaderView" id="861518097">
 											<reference key="NSNextResponder" ref="875202178"/>
 											<int key="NSvFlags">256</int>
-											<string key="NSFrameSize">{435, 17}</string>
+											<string key="NSFrameSize">{436, 17}</string>
 											<reference key="NSSuperview" ref="875202178"/>
 											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="354840670"/>
@@ -787,23 +787,24 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
-											<object class="NSTableColumn" id="268387309">
-												<string key="NSIdentifier">type</string>
-												<double key="NSWidth">60</double>
-												<double key="NSMinWidth">40</double>
-												<double key="NSMaxWidth">1000</double>
+											<object class="NSTableColumn" id="1051297816">
+												<double key="NSWidth">13</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
-													<string key="NSContents">Type</string>
+													<string key="NSContents">✓</string>
 													<object class="NSFont" key="NSSupport" id="26">
 														<string key="NSName">LucidaGrande</string>
 														<double key="NSSize">11</double>
 														<int key="NSfFlags">3100</int>
 													</object>
-													<object class="NSColor" key="NSBackgroundColor" id="525462076">
-														<int key="NSColorSpace">3</int>
-														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													<object class="NSColor" key="NSBackgroundColor" id="670571034">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="148158933"/>
 													</object>
 													<object class="NSColor" key="NSTextColor" id="1053247614">
 														<int key="NSColorSpace">6</int>
@@ -812,9 +813,10 @@
 														<reference key="NSColor" ref="851406188"/>
 													</object>
 												</object>
-												<object class="NSTextFieldCell" key="NSDataCell" id="314258589">
+												<object class="NSTextFieldCell" key="NSDataCell" id="831015614">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
 													<reference key="NSSupport" ref="806370697"/>
 													<reference key="NSControlView" ref="1057557008"/>
 													<object class="NSColor" key="NSBackgroundColor" id="988621520">
@@ -829,9 +831,37 @@
 												<bool key="NSIsResizeable">YES</bool>
 												<reference key="NSTableView" ref="1057557008"/>
 											</object>
+											<object class="NSTableColumn" id="268387309">
+												<string key="NSIdentifier">type</string>
+												<double key="NSWidth">55</double>
+												<double key="NSMinWidth">40</double>
+												<double key="NSMaxWidth">1000</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Type</string>
+													<reference key="NSSupport" ref="26"/>
+													<object class="NSColor" key="NSBackgroundColor" id="525462076">
+														<int key="NSColorSpace">3</int>
+														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
+													</object>
+													<reference key="NSTextColor" ref="1053247614"/>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="314258589">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<reference key="NSSupport" ref="806370697"/>
+													<reference key="NSControlView" ref="1057557008"/>
+													<reference key="NSBackgroundColor" ref="988621520"/>
+													<reference key="NSTextColor" ref="786413591"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="1057557008"/>
+											</object>
 											<object class="NSTableColumn" id="484043138">
 												<string key="NSIdentifier">description</string>
-												<double key="NSWidth">145.8720703125</double>
+												<double key="NSWidth">143.8720703125</double>
 												<double key="NSMinWidth">40</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -857,7 +887,7 @@
 											</object>
 											<object class="NSTableColumn" id="753043041">
 												<string key="NSIdentifier">location</string>
-												<double key="NSWidth">86.20263671875</double>
+												<double key="NSWidth">81.20263671875</double>
 												<double key="NSMinWidth">10</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -865,12 +895,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Contexte</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="670571034">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="148158933"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="670571034"/>
 													<reference key="NSTextColor" ref="1053247614"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="488432484">
@@ -887,7 +912,7 @@
 											</object>
 											<object class="NSTableColumn" id="82534825">
 												<string key="NSIdentifier">confidence</string>
-												<double key="NSWidth">130.92529296875</double>
+												<double key="NSWidth">124.92529296875</double>
 												<double key="NSMinWidth">63.92529296875</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -941,7 +966,7 @@
 										<int key="NSTableViewGroupRowStyle">1</int>
 									</object>
 								</array>
-								<string key="NSFrame">{{1, 17}, {435, 198}}</string>
+								<string key="NSFrame">{{1, 17}, {436, 198}}</string>
 								<reference key="NSSuperview" ref="479854319"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="1057557008"/>
@@ -964,15 +989,15 @@
 							<object class="NSScroller" id="592256119">
 								<reference key="NSNextResponder" ref="479854319"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="479854319"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="875202178"/>
+								<reference key="NSNextKeyView" ref="716182453"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="479854319"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.86653386454183268</double>
 							</object>
 							<object class="NSClipView" id="875202178">
 								<reference key="NSNextResponder" ref="479854319"/>
@@ -980,7 +1005,7 @@
 								<array class="NSMutableArray" key="NSSubviews">
 									<reference ref="861518097"/>
 								</array>
-								<string key="NSFrame">{{1, 0}, {435, 17}}</string>
+								<string key="NSFrame">{{1, 0}, {436, 17}}</string>
 								<reference key="NSSuperview" ref="479854319"/>
 								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="861518097"/>
@@ -989,10 +1014,10 @@
 								<int key="NScvFlags">4</int>
 							</object>
 						</array>
-						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
+						<string key="NSFrame">{{20, 48}, {438, 216}}</string>
 						<reference key="NSSuperview" ref="382071677"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="592256119"/>
+						<reference key="NSNextKeyView" ref="875202178"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="354840670"/>
 						<reference key="NSHScroller" ref="592256119"/>
@@ -1067,7 +1092,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="382071677"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="579456243">
 							<int key="NSCellFlags">67108864</int>
@@ -1091,7 +1115,7 @@
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</array>
-				<string key="NSFrameSize">{477, 284}</string>
+				<string key="NSFrameSize">{478, 284}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="479854319"/>
@@ -4894,6 +4918,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 					<int key="connectionID">1941</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="1051297816"/>
+						<reference key="destination" ref="632999034"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="1051297816"/>
+							<reference key="NSDestination" ref="632999034"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1948</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5154,6 +5198,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="82534825"/>
 							<reference ref="484043138"/>
 							<reference ref="753043041"/>
+							<reference ref="1051297816"/>
 						</array>
 						<reference key="parent" ref="479854319"/>
 					</object>
@@ -6785,6 +6830,19 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="1004189310"/>
 						<reference key="parent" ref="664030548"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1944</int>
+						<reference key="object" ref="1051297816"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="831015614"/>
+						</array>
+						<reference key="parent" ref="1057557008"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1945</int>
+						<reference key="object" ref="831015614"/>
+						<reference key="parent" ref="1051297816"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7072,6 +7130,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				</object>
 				<string key="1938.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1939.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7119,7 +7179,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1943</int>
+			<int key="maxID">1948</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/it.lproj/MainMenu.xib
+++ b/Resources/it.lproj/MainMenu.xib
@@ -769,7 +769,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="83162100"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="896946150"/>
+										<reference key="NSNextKeyView" ref="71445549"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -788,6 +788,50 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
+											<object class="NSTableColumn" id="151477662">
+												<double key="NSWidth">12</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">✓</string>
+													<object class="NSFont" key="NSSupport" id="26">
+														<string key="NSName">LucidaGrande</string>
+														<double key="NSSize">11</double>
+														<int key="NSfFlags">3100</int>
+													</object>
+													<object class="NSColor" key="NSBackgroundColor" id="703663190">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="125448428"/>
+													</object>
+													<object class="NSColor" key="NSTextColor" id="306445072">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerTextColor</string>
+														<reference key="NSColor" ref="496550321"/>
+													</object>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="592464980">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
+													<reference key="NSSupport" ref="563253970"/>
+													<reference key="NSControlView" ref="675866657"/>
+													<object class="NSColor" key="NSBackgroundColor" id="332505157">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">controlBackgroundColor</string>
+														<reference key="NSColor" ref="278693690"/>
+													</object>
+													<reference key="NSTextColor" ref="931543260"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="675866657"/>
+											</object>
 											<object class="NSTableColumn" id="634054633">
 												<string key="NSIdentifier">type</string>
 												<double key="NSWidth">57</double>
@@ -797,33 +841,19 @@
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Tipo</string>
-													<object class="NSFont" key="NSSupport" id="26">
-														<string key="NSName">LucidaGrande</string>
-														<double key="NSSize">11</double>
-														<int key="NSfFlags">3100</int>
-													</object>
+													<reference key="NSSupport" ref="26"/>
 													<object class="NSColor" key="NSBackgroundColor" id="1044927712">
 														<int key="NSColorSpace">3</int>
 														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
 													</object>
-													<object class="NSColor" key="NSTextColor" id="306445072">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerTextColor</string>
-														<reference key="NSColor" ref="496550321"/>
-													</object>
+													<reference key="NSTextColor" ref="306445072"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="588374700">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
 													<reference key="NSSupport" ref="563253970"/>
 													<reference key="NSControlView" ref="675866657"/>
-													<object class="NSColor" key="NSBackgroundColor" id="332505157">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlBackgroundColor</string>
-														<reference key="NSColor" ref="278693690"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="332505157"/>
 													<reference key="NSTextColor" ref="931543260"/>
 												</object>
 												<int key="NSResizingMask">3</int>
@@ -866,12 +896,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Contesto</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="703663190">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="125448428"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="703663190"/>
 													<reference key="NSTextColor" ref="306445072"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="226289312">
@@ -965,15 +990,15 @@
 							<object class="NSScroller" id="71445549">
 								<reference key="NSNextResponder" ref="708725706"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="708725706"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="1058842077"/>
+								<reference key="NSNextKeyView" ref="896946150"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="708725706"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.99770642201834858</double>
 							</object>
 							<object class="NSClipView" id="1058842077">
 								<reference key="NSNextResponder" ref="708725706"/>
@@ -993,7 +1018,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="825060112"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="71445549"/>
+						<reference key="NSNextKeyView" ref="1058842077"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="3815011"/>
 						<reference key="NSHScroller" ref="71445549"/>
@@ -1068,7 +1093,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="825060112"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="661775016">
 							<int key="NSCellFlags">67108864</int>
@@ -4893,6 +4917,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 					<int key="connectionID">1918</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="151477662"/>
+						<reference key="destination" ref="388804239"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="151477662"/>
+							<reference key="NSDestination" ref="388804239"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1926</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5177,6 +5221,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="212016047"/>
 							<reference ref="736735907"/>
 							<reference ref="520557415"/>
+							<reference ref="151477662"/>
 						</array>
 						<reference key="parent" ref="708725706"/>
 					</object>
@@ -6784,6 +6829,19 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="639072850"/>
 						<reference key="parent" ref="790403932"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1921</int>
+						<reference key="object" ref="151477662"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="592464980"/>
+						</array>
+						<reference key="parent" ref="675866657"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1922</int>
+						<reference key="object" ref="592464980"/>
+						<reference key="parent" ref="151477662"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7068,6 +7126,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				</object>
 				<string key="1915.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1916.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1921.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1922.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7115,7 +7175,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1920</int>
+			<int key="maxID">1926</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/pt-BR.lproj/MainMenu.xib
+++ b/Resources/pt-BR.lproj/MainMenu.xib
@@ -769,7 +769,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="648544117"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="1060926526"/>
+										<reference key="NSNextKeyView" ref="752042160"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -788,6 +788,50 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
+											<object class="NSTableColumn" id="240804664">
+												<double key="NSWidth">13</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">✓</string>
+													<object class="NSFont" key="NSSupport" id="26">
+														<string key="NSName">LucidaGrande</string>
+														<double key="NSSize">11</double>
+														<int key="NSfFlags">3100</int>
+													</object>
+													<object class="NSColor" key="NSBackgroundColor" id="739573764">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="131950345"/>
+													</object>
+													<object class="NSColor" key="NSTextColor" id="906498805">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerTextColor</string>
+														<reference key="NSColor" ref="463031444"/>
+													</object>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="69926628">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
+													<reference key="NSSupport" ref="614567188"/>
+													<reference key="NSControlView" ref="76253405"/>
+													<object class="NSColor" key="NSBackgroundColor" id="67747324">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">controlBackgroundColor</string>
+														<reference key="NSColor" ref="1071431383"/>
+													</object>
+													<reference key="NSTextColor" ref="741632344"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="76253405"/>
+											</object>
 											<object class="NSTableColumn" id="149355763">
 												<string key="NSIdentifier">type</string>
 												<double key="NSWidth">57</double>
@@ -797,33 +841,19 @@
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Tipo</string>
-													<object class="NSFont" key="NSSupport" id="26">
-														<string key="NSName">LucidaGrande</string>
-														<double key="NSSize">11</double>
-														<int key="NSfFlags">3100</int>
-													</object>
+													<reference key="NSSupport" ref="26"/>
 													<object class="NSColor" key="NSBackgroundColor" id="213025242">
 														<int key="NSColorSpace">3</int>
 														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
 													</object>
-													<object class="NSColor" key="NSTextColor" id="906498805">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerTextColor</string>
-														<reference key="NSColor" ref="463031444"/>
-													</object>
+													<reference key="NSTextColor" ref="906498805"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="511760141">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
 													<reference key="NSSupport" ref="614567188"/>
 													<reference key="NSControlView" ref="76253405"/>
-													<object class="NSColor" key="NSBackgroundColor" id="67747324">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlBackgroundColor</string>
-														<reference key="NSColor" ref="1071431383"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="67747324"/>
 													<reference key="NSTextColor" ref="741632344"/>
 												</object>
 												<int key="NSResizingMask">3</int>
@@ -866,12 +896,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Contexto</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="739573764">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="131950345"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="739573764"/>
 													<reference key="NSTextColor" ref="906498805"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="271950155">
@@ -888,7 +913,7 @@
 											</object>
 											<object class="NSTableColumn" id="633965732">
 												<string key="NSIdentifier">confidence</string>
-												<double key="NSWidth">126.89453125</double>
+												<double key="NSWidth">123.89453125</double>
 												<double key="NSMinWidth">63.92529296875</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -965,15 +990,15 @@
 							<object class="NSScroller" id="752042160">
 								<reference key="NSNextResponder" ref="790804737"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="790804737"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="440226565"/>
+								<reference key="NSNextKeyView" ref="1060926526"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="790804737"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.99770642201834858</double>
 							</object>
 							<object class="NSClipView" id="440226565">
 								<reference key="NSNextResponder" ref="790804737"/>
@@ -993,7 +1018,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="280217310"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="752042160"/>
+						<reference key="NSNextKeyView" ref="440226565"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="609388239"/>
 						<reference key="NSHScroller" ref="752042160"/>
@@ -1068,7 +1093,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="280217310"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="502912008">
 							<int key="NSCellFlags">67108864</int>
@@ -4892,6 +4916,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 					<int key="connectionID">1920</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="240804664"/>
+						<reference key="destination" ref="151153385"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="240804664"/>
+							<reference key="NSDestination" ref="151153385"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1928</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5176,6 +5220,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="633965732"/>
 							<reference ref="758234971"/>
 							<reference ref="756947141"/>
+							<reference ref="240804664"/>
 						</array>
 						<reference key="parent" ref="790804737"/>
 					</object>
@@ -6783,6 +6828,19 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="237000286"/>
 						<reference key="parent" ref="774713215"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1924</int>
+						<reference key="object" ref="240804664"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="69926628"/>
+						</array>
+						<reference key="parent" ref="76253405"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1925</int>
+						<reference key="object" ref="69926628"/>
+						<reference key="parent" ref="240804664"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7067,6 +7125,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				</object>
 				<string key="1916.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1917.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1924.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1925.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7114,7 +7174,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1923</int>
+			<int key="maxID">1928</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Resources/pt-PT.lproj/MainMenu.xib
+++ b/Resources/pt-PT.lproj/MainMenu.xib
@@ -761,7 +761,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="916458113"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="829084382"/>
+										<reference key="NSNextKeyView" ref="729802760"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -780,6 +780,50 @@
 											<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 										</object>
 										<array class="NSMutableArray" key="NSTableColumns">
+											<object class="NSTableColumn" id="259067236">
+												<double key="NSWidth">13</double>
+												<double key="NSMinWidth">10</double>
+												<double key="NSMaxWidth">3.4028234663852886e+38</double>
+												<object class="NSTableHeaderCell" key="NSHeaderCell">
+													<int key="NSCellFlags">75497536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">✓</string>
+													<object class="NSFont" key="NSSupport" id="26">
+														<string key="NSName">LucidaGrande</string>
+														<double key="NSSize">11</double>
+														<int key="NSfFlags">3100</int>
+													</object>
+													<object class="NSColor" key="NSBackgroundColor" id="652195632">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerColor</string>
+														<reference key="NSColor" ref="326007814"/>
+													</object>
+													<object class="NSColor" key="NSTextColor" id="932037218">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">headerTextColor</string>
+														<reference key="NSColor" ref="43650902"/>
+													</object>
+												</object>
+												<object class="NSTextFieldCell" key="NSDataCell" id="856175393">
+													<int key="NSCellFlags">337641536</int>
+													<int key="NSCellFlags2">2048</int>
+													<string key="NSContents">Text Cell</string>
+													<reference key="NSSupport" ref="677502429"/>
+													<reference key="NSControlView" ref="429936463"/>
+													<object class="NSColor" key="NSBackgroundColor" id="537404427">
+														<int key="NSColorSpace">6</int>
+														<string key="NSCatalogName">System</string>
+														<string key="NSColorName">controlBackgroundColor</string>
+														<reference key="NSColor" ref="15766681"/>
+													</object>
+													<reference key="NSTextColor" ref="249372474"/>
+												</object>
+												<int key="NSResizingMask">3</int>
+												<bool key="NSIsResizeable">YES</bool>
+												<reference key="NSTableView" ref="429936463"/>
+											</object>
 											<object class="NSTableColumn" id="680444923">
 												<string key="NSIdentifier">type</string>
 												<double key="NSWidth">57</double>
@@ -789,33 +833,19 @@
 													<int key="NSCellFlags">75497536</int>
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Tipo</string>
-													<object class="NSFont" key="NSSupport" id="26">
-														<string key="NSName">LucidaGrande</string>
-														<double key="NSSize">11</double>
-														<int key="NSfFlags">3100</int>
-													</object>
+													<reference key="NSSupport" ref="26"/>
 													<object class="NSColor" key="NSBackgroundColor" id="808439282">
 														<int key="NSColorSpace">3</int>
 														<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
 													</object>
-													<object class="NSColor" key="NSTextColor" id="932037218">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerTextColor</string>
-														<reference key="NSColor" ref="43650902"/>
-													</object>
+													<reference key="NSTextColor" ref="932037218"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="629124962">
 													<int key="NSCellFlags">337641536</int>
 													<int key="NSCellFlags2">2048</int>
 													<reference key="NSSupport" ref="677502429"/>
 													<reference key="NSControlView" ref="429936463"/>
-													<object class="NSColor" key="NSBackgroundColor" id="537404427">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlBackgroundColor</string>
-														<reference key="NSColor" ref="15766681"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="537404427"/>
 													<reference key="NSTextColor" ref="249372474"/>
 												</object>
 												<int key="NSResizingMask">3</int>
@@ -858,12 +888,7 @@
 													<int key="NSCellFlags2">2048</int>
 													<string key="NSContents">Contexto</string>
 													<reference key="NSSupport" ref="26"/>
-													<object class="NSColor" key="NSBackgroundColor" id="652195632">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">headerColor</string>
-														<reference key="NSColor" ref="326007814"/>
-													</object>
+													<reference key="NSBackgroundColor" ref="652195632"/>
 													<reference key="NSTextColor" ref="932037218"/>
 												</object>
 												<object class="NSTextFieldCell" key="NSDataCell" id="552367397">
@@ -880,7 +905,7 @@
 											</object>
 											<object class="NSTableColumn" id="639626398">
 												<string key="NSIdentifier">confidence</string>
-												<double key="NSWidth">126.92529296875</double>
+												<double key="NSWidth">123.92529296875</double>
 												<double key="NSMinWidth">63.92529296875</double>
 												<double key="NSMaxWidth">1000</double>
 												<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -957,15 +982,15 @@
 							<object class="NSScroller" id="729802760">
 								<reference key="NSNextResponder" ref="490514779"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {420, 15}}</string>
+								<string key="NSFrame">{{1, 199}, {435, 16}}</string>
 								<reference key="NSSuperview" ref="490514779"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="217639070"/>
+								<reference key="NSNextKeyView" ref="829084382"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="490514779"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.96551722288131714</double>
+								<double key="NSPercent">0.99542334096109841</double>
 							</object>
 							<object class="NSClipView" id="217639070">
 								<reference key="NSNextResponder" ref="490514779"/>
@@ -985,7 +1010,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="273226987"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="729802760"/>
+						<reference key="NSNextKeyView" ref="217639070"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="439280017"/>
 						<reference key="NSHScroller" ref="729802760"/>
@@ -1060,7 +1085,6 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="273226987"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="338340382">
 							<int key="NSCellFlags">67108864</int>
@@ -4951,6 +4975,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 					<int key="connectionID">2052</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.status</string>
+						<reference key="source" ref="259067236"/>
+						<reference key="destination" ref="736607620"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="259067236"/>
+							<reference key="NSDestination" ref="736607620"/>
+							<string key="NSLabel">value: arrangedObjects.status</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.status</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSAllowsEditingMultipleValuesSelection</string>
+								<boolean value="NO" key="NS.object.0"/>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">2061</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -5227,6 +5271,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="639626398"/>
 							<reference ref="683956143"/>
 							<reference ref="886118329"/>
+							<reference ref="259067236"/>
 						</array>
 						<reference key="parent" ref="490514779"/>
 					</object>
@@ -6842,6 +6887,19 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="545498138"/>
 						<reference key="parent" ref="367410236"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2057</int>
+						<reference key="object" ref="259067236"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="856175393"/>
+						</array>
+						<reference key="parent" ref="429936463"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2058</int>
+						<reference key="object" ref="856175393"/>
+						<reference key="parent" ref="259067236"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7126,6 +7184,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				</object>
 				<string key="2048.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2049.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2057.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2058.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7182,7 +7242,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">2056</int>
+			<int key="maxID">2061</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Source/CPController.h
+++ b/Source/CPController.h
@@ -53,6 +53,8 @@
 @property (readwrite) BOOL goingToSleep;
 @property (strong) NSArray *activeContexts;
 
+@property (copy,nonatomic,readwrite) NSArray *activeRules;
+
 - (NSString *) currentContextName;
 - (ContextsDataSource *) contextsDataSource;
 - (BOOL) stickyContext;

--- a/Source/PrefsWindowController.m
+++ b/Source/PrefsWindowController.m
@@ -18,6 +18,8 @@
 	ContextsDataSource *contextsDataSource;
 }
 @end
+@interface RuleStatusResultTransformer : NSValueTransformer
+@end
 
 
 @implementation ActionTypeHelpTransformer
@@ -124,6 +126,21 @@
 
 @end
 
+@implementation RuleStatusResultTransformer
+
++ (Class)transformedValueClass { return [NSString class]; }
+
++ (BOOL)allowsReverseTransformation { return NO; }
+
+- (id)transformedValue:(id)theValue {
+    if (!theValue) {
+        return  @"?";
+    }
+    return ([theValue boolValue]) ? (@"\u2713") : (@"");
+}
+
+@end
+
 #pragma mark -
 
 @interface PrefsWindowController ()
@@ -153,6 +170,8 @@
 					forName:@"LocalizeTransformer"];
 	[NSValueTransformer setValueTransformer:[[[WhenLocalizeTransformer alloc] init] autorelease]
 					forName:@"WhenLocalizeTransformer"];
+	[NSValueTransformer setValueTransformer:[[[RuleStatusResultTransformer alloc] init] autorelease]
+                    forName:@"RuleStatusResultTransformer"];
 }
 
 - (id)init


### PR DESCRIPTION
This is a small enhancement to CP that allows the users to explicitly see (in Preferences/Rules) which of their rules are currently matching and which are not.

Additionally, the changes made allowed an extra small performance improvement too: When the rules that match are exactly the same as during the previous check(s) -- and no changes to the rules or contexts have been made by the user, -- then it is not required to perform the whole re-calculation on the contexts and confidence levels as the result will be the same.

I would like to ask the team, those who can build from sources on their own, to try this enhancement on their systems.

Let me know if you like it and if you have any notes or comments from trying it in practice. Or from reviewing the related code.
