### PR TITLE
Allow using context-specific user-defined colors for status bar icon

### DIFF
--- a/ControlPlane.xcodeproj/project.pbxproj
+++ b/ControlPlane.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7C4855C0174941C500D8EB84 /* IPv6RuleType.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4855BF174941C500D8EB84 /* IPv6RuleType.m */; };
 		7C6D94591747A1BE00D5B9C7 /* IPAddrEvidenceSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C6D94581747A1BE00D5B9C7 /* IPAddrEvidenceSource.m */; };
 		7C6D945C1747A1F300D5B9C7 /* IPv4RuleType.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C6D945B1747A1F300D5B9C7 /* IPv4RuleType.m */; };
+		7C841D80175A904A000BDA66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C841D7F175A904A000BDA66 /* QuartzCore.framework */; };
 		7C8574EC16FB52AF0081659A /* DNSEvidenceSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C8574EB16FB52AF0081659A /* DNSEvidenceSource.m */; };
 		7C8574F116FB53180081659A /* ServerAddressRuleType.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C8574F016FB53180081659A /* ServerAddressRuleType.m */; };
 		7CFF034917246B770098990F /* SearchDomainRule.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7CFF034B17246B770098990F /* SearchDomainRule.xib */; };
@@ -211,13 +212,6 @@
 			remoteGlobalIDString = DAD8898E15D5F337009F30A3;
 			remoteInfo = NotificationCenterAction;
 		};
-		DAD889AE15D5F3CD009F30A3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DAD889A315D5F337009F30A3 /* NotificationCenterAction.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = DAD8898D15D5F337009F30A3;
-			remoteInfo = NotificationCenterAction;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -341,6 +335,7 @@
 		7C6D94581747A1BE00D5B9C7 /* IPAddrEvidenceSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IPAddrEvidenceSource.m; path = Source/IPAddrEvidenceSource.m; sourceTree = "<group>"; };
 		7C6D945A1747A1E400D5B9C7 /* IPv4RuleType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPv4RuleType.h; path = Source/IPv4RuleType.h; sourceTree = "<group>"; };
 		7C6D945B1747A1F300D5B9C7 /* IPv4RuleType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IPv4RuleType.m; path = Source/IPv4RuleType.m; sourceTree = "<group>"; };
+		7C841D7F175A904A000BDA66 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		7C8574EA16FB52AF0081659A /* DNSEvidenceSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DNSEvidenceSource.h; path = Source/DNSEvidenceSource.h; sourceTree = "<group>"; };
 		7C8574EB16FB52AF0081659A /* DNSEvidenceSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DNSEvidenceSource.m; path = Source/DNSEvidenceSource.m; sourceTree = "<group>"; };
 		7C8574EF16FB53180081659A /* ServerAddressRuleType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerAddressRuleType.h; path = Source/ServerAddressRuleType.h; sourceTree = "<group>"; };
@@ -659,6 +654,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7C841D80175A904A000BDA66 /* QuartzCore.framework in Frameworks */,
 				DAC817B1159BF95A0012ED43 /* ServiceManagement.framework in Frameworks */,
 				DA8E2833156B498A0040FC35 /* ApplicationServices.framework in Frameworks */,
 				8D8C9BAB0BBB3ADB0074D5B3 /* Apple80211.framework in Frameworks */,
@@ -762,6 +758,7 @@
 				8DB8911C0BB88D0B005347C2 /* IOBluetooth.framework */,
 				8D481B070B6098DD0097CF9C /* IOKit.framework */,
 				DA48F2E3140AD2FC00B000D3 /* Kernel.framework */,
+				7C841D7F175A904A000BDA66 /* QuartzCore.framework */,
 				DDAC3C54140D866200FBF29E /* ScriptingBridge.framework */,
 				DD8274FA141177750098FA6E /* Security.framework */,
 				DAC817B0159BF95A0012ED43 /* ServiceManagement.framework */,
@@ -1229,7 +1226,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				DAD889AF15D5F3CD009F30A3 /* PBXTargetDependency */,
 				DA5B02071412BB3A00E19C50 /* PBXTargetDependency */,
 				DA5B01E31412B78900E19C50 /* PBXTargetDependency */,
 			);
@@ -1596,11 +1592,6 @@
 			isa = PBXTargetDependency;
 			target = DA5B01FA1412BB1700E19C50 /* com.dustinrue.CPHelperTool */;
 			targetProxy = DA5B02061412BB3A00E19C50 /* PBXContainerItemProxy */;
-		};
-		DAD889AF15D5F3CD009F30A3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = NotificationCenterAction;
-			targetProxy = DAD889AE15D5F3CD009F30A3 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Resources/da-DK.lproj/MainMenu.xib
+++ b/Resources/da-DK.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -769,7 +770,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="982186366"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="651013189"/>
+										<reference key="NSNextKeyView" ref="1007950745"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1018,7 +1019,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="764886370"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="982186366"/>
+						<reference key="NSNextKeyView" ref="651013189"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="496414959"/>
 						<reference key="NSHScroller" ref="1007950745"/>
@@ -1093,6 +1094,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="764886370"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="700875448">
 							<int key="NSCellFlags">67108864</int>
@@ -1102,7 +1104,7 @@
 							<reference key="NSControlView" ref="695959897"/>
 							<int key="NSButtonFlags">-2033958912</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="743877007">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1847,6 +1849,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{18, 310}, {106, 18}}</string>
 						<reference key="NSSuperview" ref="376363581"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="144015011"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="700261366">
 							<int key="NSCellFlags">67108864</int>
@@ -1871,6 +1874,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{17, 334}, {431, 34}}</string>
 						<reference key="NSSuperview" ref="376363581"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="294815663"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="408167963">
 							<int key="NSCellFlags">67108864</int>
@@ -1898,6 +1902,7 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 										<string key="NSFrame">{{13, 7}, {399, 18}}</string>
 										<reference key="NSSuperview" ref="673531236"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="933670919"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="744046534">
 											<int key="NSCellFlags">67108864</int>
@@ -1922,6 +1927,7 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 										<string key="NSFrame">{{16, 31}, {200, 13}}</string>
 										<reference key="NSSuperview" ref="673531236"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="174628293"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="233782964">
 											<int key="NSCellFlags">67108864</int>
@@ -1940,6 +1946,7 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 										<string key="NSFrame">{{222, 27}, {118, 21}}</string>
 										<reference key="NSSuperview" ref="673531236"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="863782264"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="368833128">
 											<int key="NSCellFlags">67371264</int>
@@ -1966,6 +1973,7 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 										<string key="NSFrame">{{346, 31}, {65, 13}}</string>
 										<reference key="NSSuperview" ref="673531236"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="387356918"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="592705556">
 											<int key="NSCellFlags">67108864</int>
@@ -1982,11 +1990,13 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 								<string key="NSFrame">{{2, 2}, {427, 57}}</string>
 								<reference key="NSSuperview" ref="144015011"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="562678629"/>
 							</object>
 						</array>
 						<string key="NSFrame">{{17, 245}, {431, 61}}</string>
 						<reference key="NSSuperview" ref="376363581"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="673531236"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
 							<int key="NSCellFlags">67108864</int>
@@ -2019,6 +2029,7 @@ ZWV2bmUuClNlIHZlbmxpZ3N0IHZlamxlZG5pbmdlbiBmb3IgZGV0YWxqZXIuA</string>
 										<string key="NSFrameSize">{423, 191}</string>
 										<reference key="NSSuperview" ref="539698107"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="444768753"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="918592677">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2111,6 +2122,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{408, 1}, {16, 191}}</string>
 								<reference key="NSSuperview" ref="933670919"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="24474783"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="933670919"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2122,6 +2134,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="933670919"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="539698107"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="933670919"/>
@@ -2133,7 +2146,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 193}}</string>
 						<reference key="NSSuperview" ref="376363581"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="539698107"/>
+						<reference key="NSNextKeyView" ref="152019260"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="444768753"/>
 						<reference key="NSHScroller" ref="152019260"/>
@@ -2148,6 +2161,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="376363581"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="418754871">
 							<int key="NSCellFlags">67108864</int>
@@ -2172,6 +2186,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{465, 388}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="440405992"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2221,6 +2236,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{304, 243}</string>
 										<reference key="NSSuperview" ref="960553556"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="831996118"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2230,6 +2246,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<string key="NSFrameSize">{304, 17}</string>
 											<reference key="NSSuperview" ref="925616886"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="960553556"/>
 											<reference key="NSTableView" ref="25306665"/>
 										</object>
 										<object class="_NSCornerView" key="NSCornerView">
@@ -2435,6 +2452,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 								<string key="NSFrame">{{289, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="771797414"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="771797414"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2446,6 +2464,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 								<string key="NSFrame">{{1, 244}, {304, 16}}</string>
 								<reference key="NSSuperview" ref="771797414"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="229344506"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="771797414"/>
@@ -2470,7 +2489,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<string key="NSFrame">{{20, 20}, {306, 261}}</string>
 						<reference key="NSSuperview" ref="626652844"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="960553556"/>
+						<reference key="NSNextKeyView" ref="925616886"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="229344506"/>
 						<reference key="NSHScroller" ref="831996118"/>
@@ -2485,6 +2504,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 				<string key="NSFrameSize">{346, 301}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="771797414"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2701,6 +2721,32 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 			<object class="NSCustomView" id="328548046">
 				<reference key="NSNextResponder"/>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="357922390">
+						<reference key="NSNextResponder" ref="328548046"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="328548046"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="345463179">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="736811615"/>
+							<reference key="NSControlView" ref="357922390"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="743877007"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="169727786">
 						<reference key="NSNextResponder" ref="328548046"/>
 						<int key="NSvFlags">272</int>
@@ -2715,6 +2761,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="746924666"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="290546325"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2809,6 +2856,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 								<string key="NSFrame">{{-30, 1}, {15, 245}}</string>
 								<reference key="NSSuperview" ref="169727786"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="746924666"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="169727786"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2820,6 +2868,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
 								<reference key="NSSuperview" ref="169727786"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="266072541"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="169727786"/>
@@ -2830,7 +2879,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="328548046"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="746924666"/>
+						<reference key="NSNextKeyView" ref="117949597"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="266072541"/>
 						<reference key="NSHScroller" ref="117949597"/>
@@ -2875,6 +2924,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="328548046"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="357922390"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="394472799">
 							<int key="NSCellFlags">67108864</int>
@@ -2898,6 +2948,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 				<string key="NSFrameSize">{393, 315}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="169727786"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2909,7 +2960,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 			<object class="NSWindowTemplate" id="539723869">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{504, 551}, {241, 137}}</string>
+				<string key="NSWindowRect">{{504, 551}, {270, 180}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*Ny kontekst*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2921,18 +2972,20 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="744601441">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="23468751">
 							<reference key="NSNextResponder" ref="744601441"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {200, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {200, 17}}</string>
 							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="177356058"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="1026446270">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Indtast navn på ny kontekst</string>
+								<string key="NSContents">Indtast navn på kontekst</string>
 								<reference key="NSSupport" ref="736811615"/>
 								<reference key="NSControlView" ref="23468751"/>
 								<reference key="NSBackgroundColor" ref="914014326"/>
@@ -2943,8 +2996,10 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<object class="NSTextField" id="177356058">
 							<reference key="NSNextResponder" ref="744601441"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {201, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="120535889"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="73734166">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2961,8 +3016,10 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<object class="NSButton" id="596474504">
 							<reference key="NSNextResponder" ref="744601441"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{145, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{174, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="241106837">
 								<int key="NSCellFlags">67108864</int>
@@ -2983,8 +3040,10 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<object class="NSButton" id="48774416">
 							<reference key="NSNextResponder" ref="744601441"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{51, 22}, {94, 32}}</string>
+							<string key="NSFrame">{{80, 13}, {94, 32}}</string>
 							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="596474504"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="117602653">
 								<int key="NSCellFlags">67108864</int>
@@ -3002,8 +3061,76 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="404765833">
+							<reference key="NSNextResponder" ref="744601441"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="366574657"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="120535889">
+							<reference key="NSNextResponder" ref="744601441"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="404765833"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="1014083502">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="736811615"/>
+								<reference key="NSControlView" ref="120535889"/>
+								<reference key="NSBackgroundColor" ref="914014326"/>
+								<reference key="NSTextColor" ref="468606996"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="366574657">
+							<reference key="NSNextResponder" ref="744601441"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="744601441"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="48774416"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="475796401">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="736811615"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="366574657"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="737733995"/>
+								<reference key="NSAlternateImage" ref="677465832"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrame">{{1, 1}, {241, 137}}</string>
+					<string key="NSFrameSize">{270, 180}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="23468751"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
 				<string key="NSMinSize">{213, 129}</string>
@@ -4905,6 +5032,46 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="812577353"/>
+						<reference key="destination" ref="357922390"/>
+					</object>
+					<int key="connectionID">1940</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="812577353"/>
+						<reference key="destination" ref="404765833"/>
+					</object>
+					<int key="connectionID">1946</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="812577353"/>
+						<reference key="destination" ref="366574657"/>
+					</object>
+					<int key="connectionID">1947</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="812577353"/>
+						<reference key="destination" ref="404765833"/>
+					</object>
+					<int key="connectionID">1948</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="812577353"/>
+						<reference key="destination" ref="366574657"/>
+					</object>
+					<int key="connectionID">1949</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="151006428"/>
@@ -5071,6 +5238,26 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						</object>
 					</object>
 					<int key="connectionID">1933</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="357922390"/>
+						<reference key="destination" ref="812577353"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="357922390"/>
+							<reference key="NSDestination" ref="812577353"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1939</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5855,6 +6042,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 							<reference ref="169727786"/>
 							<reference ref="290546325"/>
 							<reference ref="325415160"/>
+							<reference ref="357922390"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5933,6 +6121,9 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 							<reference ref="177356058"/>
 							<reference ref="596474504"/>
 							<reference ref="48774416"/>
+							<reference ref="404765833"/>
+							<reference ref="120535889"/>
+							<reference ref="366574657"/>
 						</array>
 						<reference key="parent" ref="539723869"/>
 					</object>
@@ -6977,6 +7168,50 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<reference key="object" ref="672003038"/>
 						<reference key="parent" ref="908836847"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1934</int>
+						<reference key="object" ref="357922390"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="345463179"/>
+						</array>
+						<reference key="parent" ref="328548046"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1935</int>
+						<reference key="object" ref="345463179"/>
+						<reference key="parent" ref="357922390"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1941</int>
+						<reference key="object" ref="404765833"/>
+						<reference key="parent" ref="744601441"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1942</int>
+						<reference key="object" ref="120535889"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="1014083502"/>
+						</array>
+						<reference key="parent" ref="744601441"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1943</int>
+						<reference key="object" ref="366574657"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="475796401"/>
+						</array>
+						<reference key="parent" ref="744601441"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1944</int>
+						<reference key="object" ref="475796401"/>
+						<reference key="parent" ref="366574657"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1945</int>
+						<reference key="object" ref="1014083502"/>
+						<reference key="parent" ref="120535889"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7267,6 +7502,13 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 				<string key="1917.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1923.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1924.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1934.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1935.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1941.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1942.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7312,7 +7554,7 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1933</int>
+			<int key="maxID">1949</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7409,6 +7651,8 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7417,6 +7661,14 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7540,7 +7792,6 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7578,10 +7829,6 @@ AAAAAAAAAAAAAHRleHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Resources/de.lproj/MainMenu.xib
+++ b/Resources/de.lproj/MainMenu.xib
@@ -16,6 +16,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -763,7 +764,7 @@
 										<string key="NSFrameSize">{438, 198}</string>
 										<reference key="NSSuperview" ref="136212862"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="44901239"/>
+										<reference key="NSNextKeyView" ref="215464208"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1014,7 +1015,7 @@
 						<string key="NSFrame">{{20, 48}, {440, 216}}</string>
 						<reference key="NSSuperview" ref="889027356"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="136212862"/>
+						<reference key="NSNextKeyView" ref="44901239"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="662548180"/>
 						<reference key="NSHScroller" ref="215464208"/>
@@ -1089,6 +1090,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="889027356"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="221425782">
 							<int key="NSCellFlags">67108864</int>
@@ -1098,7 +1100,7 @@
 							<reference key="NSControlView" ref="661566747"/>
 							<int key="NSButtonFlags">-2033958912</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="938831636">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1849,6 +1851,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{18, 296}, {106, 18}}</string>
 						<reference key="NSSuperview" ref="194601325"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="542264652"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="308529832">
 							<int key="NSCellFlags">67108864</int>
@@ -1873,6 +1876,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{17, 318}, {431, 51}}</string>
 						<reference key="NSSuperview" ref="194601325"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="834165614"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="642204550">
 							<int key="NSCellFlags">67108864</int>
@@ -1901,6 +1905,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{13, 7}, {400, 18}}</string>
 										<reference key="NSSuperview" ref="654485413"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="118704844"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="854841636">
 											<int key="NSCellFlags">67108864</int>
@@ -1925,6 +1930,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{16, 54}, {268, 13}}</string>
 										<reference key="NSSuperview" ref="654485413"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="625926289"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="959868643">
 											<int key="NSCellFlags">67108864</int>
@@ -1943,6 +1949,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{14, 27}, {272, 21}}</string>
 										<reference key="NSSuperview" ref="654485413"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="950479943"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="230485677">
 											<int key="NSCellFlags">67371264</int>
@@ -1969,6 +1976,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{292, 31}, {119, 13}}</string>
 										<reference key="NSSuperview" ref="654485413"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="512943125"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="1005621729">
 											<int key="NSCellFlags">67108864</int>
@@ -1985,11 +1993,13 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 								<string key="NSFrame">{{2, 2}, {427, 80}}</string>
 								<reference key="NSSuperview" ref="542264652"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="934826219"/>
 							</object>
 						</object>
 						<string key="NSFrame">{{17, 208}, {431, 84}}</string>
 						<reference key="NSSuperview" ref="194601325"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="654485413"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
 							<int key="NSCellFlags">67108864</int>
@@ -2024,6 +2034,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrameSize">{423, 154}</string>
 										<reference key="NSSuperview" ref="615190606"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="397253451"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="466850640">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2137,6 +2148,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{408, 1}, {16, 154}}</string>
 								<reference key="NSSuperview" ref="118704844"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="672406599"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="118704844"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2148,6 +2160,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="118704844"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="615190606"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="118704844"/>
@@ -2159,7 +2172,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 156}}</string>
 						<reference key="NSSuperview" ref="194601325"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="615190606"/>
+						<reference key="NSNextKeyView" ref="683967242"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="397253451"/>
 						<reference key="NSHScroller" ref="683967242"/>
@@ -2174,6 +2187,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="194601325"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="663172447">
 							<int key="NSCellFlags">67108864</int>
@@ -2198,6 +2212,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{465, 389}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="745972873"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2252,6 +2267,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="228613476"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="325659346"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2261,6 +2277,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<string key="NSFrameSize">{347, 17}</string>
 											<reference key="NSSuperview" ref="770169207"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="228613476"/>
 											<reference key="NSTableView" ref="589079095"/>
 										</object>
 										<object class="_NSCornerView" key="NSCornerView">
@@ -2469,6 +2486,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="381364249"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="381364249"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2480,6 +2498,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 								<string key="NSFrame">{{1, 244}, {347, 16}}</string>
 								<reference key="NSSuperview" ref="381364249"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="886509969"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="381364249"/>
@@ -2505,7 +2524,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="693981160"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="228613476"/>
+						<reference key="NSNextKeyView" ref="770169207"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="886509969"/>
 						<reference key="NSHScroller" ref="325659346"/>
@@ -2520,6 +2539,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<string key="NSFrameSize">{389, 301}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="381364249"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2740,6 +2760,32 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<reference key="NSNextResponder"/>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="NSButton" id="624579037">
+						<reference key="NSNextResponder" ref="1023414994"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="1023414994"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="549501253">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="595299968"/>
+							<reference key="NSControlView" ref="624579037"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="938831636"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="663700252">
 						<reference key="NSNextResponder" ref="1023414994"/>
 						<int key="NSvFlags">272</int>
@@ -2756,6 +2802,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="703575626"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="520284132"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2851,6 +2898,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 								<string key="NSFrame">{{-30, 1}, {15, 245}}</string>
 								<reference key="NSSuperview" ref="663700252"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="703575626"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="663700252"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2862,6 +2910,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
 								<reference key="NSSuperview" ref="663700252"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="921619358"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="663700252"/>
@@ -2872,7 +2921,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="1023414994"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="703575626"/>
+						<reference key="NSNextKeyView" ref="27085254"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="921619358"/>
 						<reference key="NSHScroller" ref="27085254"/>
@@ -2917,6 +2966,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="1023414994"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="624579037"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="395596424">
 							<int key="NSCellFlags">67108864</int>
@@ -2940,6 +2990,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<string key="NSFrameSize">{393, 315}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="663700252"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2951,7 +3002,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 			<object class="NSWindowTemplate" id="475908032">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{250, 446}, {241, 137}}</string>
+				<string key="NSWindowRect">{{250, 446}, {270, 177}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2963,19 +3014,21 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="721065414">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<object class="NSMutableArray" key="NSSubviews">
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSTextField" id="408108480">
 							<reference key="NSNextResponder" ref="721065414"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {207, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {207, 17}}</string>
 							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="748896609"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="596448357">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Name der neuen Umgebung</string>
+								<string key="NSContents">Name der Umgebung</string>
 								<reference key="NSSupport" ref="595299968"/>
 								<reference key="NSControlView" ref="408108480"/>
 								<reference key="NSBackgroundColor" ref="927019150"/>
@@ -2986,8 +3039,10 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSTextField" id="748896609">
 							<reference key="NSNextResponder" ref="721065414"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {201, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="548355744"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="470202255">
 								<int key="NSCellFlags">-1804599231</int>
@@ -3004,8 +3059,10 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSButton" id="417490798">
 							<reference key="NSNextResponder" ref="721065414"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{145, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{174, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="1027098911">
 								<int key="NSCellFlags">67108864</int>
@@ -3026,8 +3083,10 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSButton" id="997186575">
 							<reference key="NSNextResponder" ref="721065414"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{37, 22}, {108, 32}}</string>
+							<string key="NSFrame">{{66, 13}, {108, 32}}</string>
 							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="417490798"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="692213781">
 								<int key="NSCellFlags">67108864</int>
@@ -3045,8 +3104,80 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="686008689">
+							<reference key="NSNextResponder" ref="721065414"/>
+							<int key="NSvFlags">268</int>
+							<object class="NSMutableSet" key="NSDragTypes">
+								<bool key="EncodedWithXMLCoder">YES</bool>
+								<object class="NSArray" key="set.sortedObjects">
+									<bool key="EncodedWithXMLCoder">YES</bool>
+									<string>NSColor pasteboard type</string>
+								</object>
+							</object>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="407836287"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="548355744">
+							<reference key="NSNextResponder" ref="721065414"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="686008689"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="399572523">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="595299968"/>
+								<reference key="NSControlView" ref="548355744"/>
+								<reference key="NSBackgroundColor" ref="927019150"/>
+								<reference key="NSTextColor" ref="1013935801"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="407836287">
+							<reference key="NSNextResponder" ref="721065414"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="721065414"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="997186575"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="710886853">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="595299968"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="407836287"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="1016868003"/>
+								<reference key="NSAlternateImage" ref="849169191"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</object>
-					<string key="NSFrameSize">{241, 137}</string>
+					<string key="NSFrameSize">{270, 177}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="408108480"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
 				<string key="NSMinSize">{213, 129}</string>
@@ -5057,6 +5188,46 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="417924713"/>
+						<reference key="destination" ref="624579037"/>
+					</object>
+					<int key="connectionID">1963</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="417924713"/>
+						<reference key="destination" ref="686008689"/>
+					</object>
+					<int key="connectionID">1969</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="417924713"/>
+						<reference key="destination" ref="407836287"/>
+					</object>
+					<int key="connectionID">1970</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="417924713"/>
+						<reference key="destination" ref="686008689"/>
+					</object>
+					<int key="connectionID">1971</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="417924713"/>
+						<reference key="destination" ref="407836287"/>
+					</object>
+					<int key="connectionID">1972</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="308174686"/>
@@ -5233,6 +5404,26 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">1956</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="624579037"/>
+						<reference key="destination" ref="417924713"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="624579037"/>
+							<reference key="NSDestination" ref="417924713"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1962</int>
 				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -6087,6 +6278,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<reference ref="663700252"/>
 							<reference ref="520284132"/>
 							<reference ref="26747228"/>
+							<reference ref="624579037"/>
 						</object>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -6173,6 +6365,9 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<reference ref="748896609"/>
 							<reference ref="417490798"/>
 							<reference ref="997186575"/>
+							<reference ref="686008689"/>
+							<reference ref="548355744"/>
+							<reference ref="407836287"/>
 						</object>
 						<reference key="parent" ref="475908032"/>
 					</object>
@@ -7246,6 +7441,53 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<reference key="object" ref="734851514"/>
 						<reference key="parent" ref="399410271"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1957</int>
+						<reference key="object" ref="624579037"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="549501253"/>
+						</object>
+						<reference key="parent" ref="1023414994"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1958</int>
+						<reference key="object" ref="549501253"/>
+						<reference key="parent" ref="624579037"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1964</int>
+						<reference key="object" ref="686008689"/>
+						<reference key="parent" ref="721065414"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1965</int>
+						<reference key="object" ref="548355744"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="399572523"/>
+						</object>
+						<reference key="parent" ref="721065414"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1966</int>
+						<reference key="object" ref="407836287"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="710886853"/>
+						</object>
+						<reference key="parent" ref="721065414"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1967</int>
+						<reference key="object" ref="710886853"/>
+						<reference key="parent" ref="407836287"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1968</int>
+						<reference key="object" ref="399572523"/>
+						<reference key="parent" ref="548355744"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -7523,6 +7765,13 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					<string>1939.IBPluginDependency</string>
 					<string>1946.IBPluginDependency</string>
 					<string>1947.IBPluginDependency</string>
+					<string>1957.IBPluginDependency</string>
+					<string>1958.IBPluginDependency</string>
+					<string>1964.IBPluginDependency</string>
+					<string>1965.IBPluginDependency</string>
+					<string>1966.IBPluginDependency</string>
+					<string>1967.IBPluginDependency</string>
+					<string>1968.IBPluginDependency</string>
 					<string>231.CustomClassName</string>
 					<string>231.IBPluginDependency</string>
 					<string>288.IBPluginDependency</string>
@@ -7851,6 +8100,13 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>DNDArrayController</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7905,7 +8161,7 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">1956</int>
+			<int key="maxID">1972</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -8052,6 +8308,8 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>newContextSheet</string>
+							<string>newContextSheetColor</string>
+							<string>newContextSheetColorPreviewEnabled</string>
 							<string>newContextSheetName</string>
 							<string>outlineView</string>
 							<string>prefsWindow</string>
@@ -8059,6 +8317,8 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>NSPanel</string>
+							<string>NSColorWell</string>
+							<string>NSButton</string>
 							<string>NSTextField</string>
 							<string>NSOutlineView</string>
 							<string>NSWindow</string>
@@ -8069,6 +8329,8 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>newContextSheet</string>
+							<string>newContextSheetColor</string>
+							<string>newContextSheetColorPreviewEnabled</string>
 							<string>newContextSheetName</string>
 							<string>outlineView</string>
 							<string>prefsWindow</string>
@@ -8078,6 +8340,14 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<object class="IBToOneOutletInfo">
 								<string key="name">newContextSheet</string>
 								<string key="candidateClassName">NSPanel</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">newContextSheetColor</string>
+								<string key="candidateClassName">NSColorWell</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">newContextSheetColorPreviewEnabled</string>
+								<string key="candidateClassName">NSButton</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">newContextSheetName</string>
@@ -8237,7 +8507,6 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<string>advancedPrefsView</string>
 							<string>contextsDataSource</string>
 							<string>contextsPrefsView</string>
-							<string>cpController</string>
 							<string>defaultContextButton</string>
 							<string>editActionContextButton</string>
 							<string>evidenceSources</string>
@@ -8262,7 +8531,6 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<string>NSView</string>
 							<string>ContextsDataSource</string>
 							<string>NSView</string>
-							<string>CPController</string>
 							<string>ContextSelectionButton</string>
 							<string>ContextSelectionButton</string>
 							<string>EvidenceSourceSetController</string>
@@ -8290,7 +8558,6 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<string>advancedPrefsView</string>
 							<string>contextsDataSource</string>
 							<string>contextsPrefsView</string>
-							<string>cpController</string>
 							<string>defaultContextButton</string>
 							<string>editActionContextButton</string>
 							<string>evidenceSources</string>
@@ -8329,10 +8596,6 @@ eHQAAAAAQ29weXJpZ2h0IEFwcGxlIENvbXB1dGVyLCBJbmMuLCAyMDA1AAAAAA</bytes>
 							<object class="IBToOneOutletInfo">
 								<string key="name">contextsPrefsView</string>
 								<string key="candidateClassName">NSView</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">cpController</string>
-								<string key="candidateClassName">CPController</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">defaultContextButton</string>

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -131,6 +132,7 @@
 						<string key="NSKeyEquiv"/>
 						<int key="NSKeyEquivModMask">1048576</int>
 						<int key="NSMnemonicLoc">2147483647</int>
+						<int key="NSState">1</int>
 						<reference key="NSOnImage" ref="1018155906"/>
 						<reference key="NSMixedImage" ref="1022509061"/>
 					</object>
@@ -1096,7 +1098,7 @@
 							<reference key="NSControlView" ref="657012302"/>
 							<int key="NSButtonFlags">-2033434624</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="364528377">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1120,7 +1122,7 @@
 				<string key="NSExtension">NSResponder</string>
 			</object>
 			<object class="NSCustomView" id="742374488">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<array class="NSMutableArray" key="NSSubviews">
 					<object class="NSScrollView" id="959334404">
@@ -1136,8 +1138,7 @@
 										<int key="NSvFlags">256</int>
 										<string key="NSFrameSize">{456, 126}</string>
 										<reference key="NSSuperview" ref="572115010"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="260542878"/>
+										<reference key="NSNextKeyView" ref="955731289"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1146,7 +1147,6 @@
 											<int key="NSvFlags">256</int>
 											<string key="NSFrameSize">{456, 17}</string>
 											<reference key="NSSuperview" ref="1069107717"/>
-											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="861096710"/>
 											<reference key="NSTableView" ref="440052586"/>
 										</object>
@@ -1299,7 +1299,6 @@
 								</array>
 								<string key="NSFrame">{{1, 17}, {456, 126}}</string>
 								<reference key="NSSuperview" ref="959334404"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="440052586"/>
 								<reference key="NSDocView" ref="440052586"/>
 								<reference key="NSBGColor" ref="537404427"/>
@@ -1310,7 +1309,6 @@
 								<int key="NSvFlags">-2147483392</int>
 								<string key="NSFrame">{{-30, 17}, {15, 126}}</string>
 								<reference key="NSSuperview" ref="959334404"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="572115010"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="959334404"/>
@@ -1322,7 +1320,6 @@
 								<int key="NSvFlags">-2147483392</int>
 								<string key="NSFrame">{{1, -30}, {441, 15}}</string>
 								<reference key="NSSuperview" ref="959334404"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="1069107717"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
@@ -1338,7 +1335,6 @@
 								</array>
 								<string key="NSFrame">{{1, 0}, {456, 17}}</string>
 								<reference key="NSSuperview" ref="959334404"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="784359478"/>
 								<reference key="NSDocView" ref="784359478"/>
 								<reference key="NSBGColor" ref="537404427"/>
@@ -1347,8 +1343,7 @@
 						</array>
 						<string key="NSFrame">{{20, 249}, {458, 144}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="955731289"/>
+						<reference key="NSNextKeyView" ref="572115010"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="861096710"/>
 						<reference key="NSHScroller" ref="955731289"/>
@@ -1364,7 +1359,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{48, 219}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1001997549"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="936409520">
@@ -1390,7 +1384,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{20, 193}, {388, 19}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="983694489"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="166382794">
@@ -1413,7 +1406,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{26, 165}, {72, 17}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="146452175"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="889136562">
@@ -1432,7 +1424,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{103, 163}, {375, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1045647451"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="237151806">
@@ -1457,7 +1448,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{103, 131}, {375, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="718389948"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="879275786">
@@ -1477,7 +1467,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{17, 133}, {81, 17}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="903940847"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="489471090">
@@ -1496,7 +1485,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{38, 98}, {59, 17}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="35176552"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="622089413">
@@ -1515,7 +1503,6 @@
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{17, 20}, {464, 42}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="208403191">
 							<int key="NSCellFlags">67108864</int>
@@ -1538,7 +1525,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{54, 71}, {43, 17}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="482392656"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="359347255">
@@ -1557,7 +1543,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{99, 66}, {130, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="767039264"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSPopUpButtonCell" key="NSCell" id="729217862">
@@ -1666,7 +1651,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">257</int>
 						<string key="NSFrame">{{325, 93}, {156, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="61880060"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSPopUpButtonCell" key="NSCell" id="231355533">
@@ -1716,7 +1700,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 219}, {29, 22}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="780915981"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="963952467">
@@ -1742,7 +1725,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">258</int>
 						<string key="NSFrame">{{99, 92}, {224, 26}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="336744950"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSPopUpButtonCell" key="NSCell" id="590822431">
@@ -1792,7 +1774,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{326, 68}, {72, 18}}</string>
 						<reference key="NSSuperview" ref="742374488"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1044394764"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="588586393">
@@ -1813,8 +1794,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 					</object>
 				</array>
 				<string key="NSFrameSize">{498, 413}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="959334404"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
@@ -1869,7 +1848,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 				<string key="NSClassName">ActionSetController</string>
 			</object>
 			<object class="NSCustomView" id="588395791">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<array class="NSMutableArray" key="NSSubviews">
 					<object class="NSButton" id="666287077">
@@ -1877,7 +1856,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">264</int>
 						<string key="NSFrame">{{18, 311}, {106, 18}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="734846967"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="832735577">
@@ -1902,7 +1880,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<int key="NSvFlags">264</int>
 						<string key="NSFrame">{{17, 335}, {431, 34}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="666287077"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="252099560">
@@ -1929,7 +1906,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<int key="NSvFlags">256</int>
 										<string key="NSFrame">{{13, 7}, {397, 18}}</string>
 										<reference key="NSSuperview" ref="576237743"/>
-										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="191536808"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="538377312">
@@ -1953,7 +1929,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<int key="NSvFlags">256</int>
 										<string key="NSFrame">{{16, 31}, {210, 13}}</string>
 										<reference key="NSSuperview" ref="576237743"/>
-										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="208011296"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="614518771">
@@ -1972,7 +1947,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<int key="NSvFlags">256</int>
 										<string key="NSFrame">{{232, 27}, {110, 21}}</string>
 										<reference key="NSSuperview" ref="576237743"/>
-										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="522941285"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="908723961">
@@ -1999,7 +1973,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<int key="NSvFlags">256</int>
 										<string key="NSFrame">{{348, 31}, {63, 13}}</string>
 										<reference key="NSSuperview" ref="576237743"/>
-										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="377814272"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="840625900">
@@ -2016,13 +1989,11 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 								</array>
 								<string key="NSFrame">{{2, 2}, {427, 57}}</string>
 								<reference key="NSSuperview" ref="734846967"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="897063824"/>
 							</object>
 						</array>
 						<string key="NSFrame">{{17, 246}, {431, 61}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="576237743"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
@@ -2055,8 +2026,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<int key="NSvFlags">2322</int>
 										<string key="NSFrameSize">{423, 192}</string>
 										<reference key="NSSuperview" ref="690402953"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="345876992"/>
+										<reference key="NSNextKeyView" ref="302758342"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="584820345">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2113,7 +2083,6 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 								</array>
 								<string key="NSFrame">{{1, 1}, {423, 192}}</string>
 								<reference key="NSSuperview" ref="191536808"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="220548516"/>
 								<reference key="NSDocView" ref="220548516"/>
 								<reference key="NSBGColor" ref="326007814"/>
@@ -2148,7 +2117,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<int key="NSvFlags">256</int>
 								<string key="NSFrame">{{408, 1}, {16, 192}}</string>
 								<reference key="NSSuperview" ref="191536808"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="557290468"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="191536808"/>
@@ -2160,7 +2128,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<int key="NSvFlags">-2147483392</int>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="191536808"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="690402953"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
@@ -2172,8 +2139,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</array>
 						<string key="NSFrame">{{20, 48}, {425, 194}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="302758342"/>
+						<reference key="NSNextKeyView" ref="690402953"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="345876992"/>
 						<reference key="NSHScroller" ref="302758342"/>
@@ -2187,7 +2153,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<int key="NSvFlags">256</int>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
-						<reference key="NSWindow"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="762195779">
 							<int key="NSCellFlags">67108864</int>
@@ -2210,8 +2175,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 				</array>
 				<string key="NSFrameSize">{465, 389}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="405910644"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
@@ -2246,7 +2209,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSClassName">EvidenceSourceSetController</string>
 			</object>
 			<object class="NSCustomView" id="830434413">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<array class="NSMutableArray" key="NSSubviews">
 					<object class="NSScrollView" id="677707641">
@@ -2262,8 +2225,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<int key="NSvFlags">256</int>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="788645002"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="420284366"/>
+										<reference key="NSNextKeyView" ref="983622499"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2272,7 +2234,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<int key="NSvFlags">256</int>
 											<string key="NSFrameSize">{347, 17}</string>
 											<reference key="NSSuperview" ref="983622499"/>
-											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="788645002"/>
 											<reference key="NSTableView" ref="938249519"/>
 										</object>
@@ -2365,7 +2326,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								</array>
 								<string key="NSFrame">{{1, 17}, {347, 243}}</string>
 								<reference key="NSSuperview" ref="677707641"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="938249519"/>
 								<reference key="NSDocView" ref="938249519"/>
 								<reference key="NSBGColor" ref="537404427"/>
@@ -2376,7 +2336,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<int key="NSvFlags">256</int>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="677707641"/>
-								<reference key="NSWindow"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="677707641"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2387,7 +2346,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<int key="NSvFlags">256</int>
 								<string key="NSFrame">{{1, 244}, {347, 16}}</string>
 								<reference key="NSSuperview" ref="677707641"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="35451329"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
@@ -2403,7 +2361,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								</array>
 								<string key="NSFrame">{{1, 0}, {347, 17}}</string>
 								<reference key="NSSuperview" ref="677707641"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="1018798052"/>
 								<reference key="NSDocView" ref="1018798052"/>
 								<reference key="NSBGColor" ref="537404427"/>
@@ -2412,8 +2369,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</array>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="830434413"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="983622499"/>
+						<reference key="NSNextKeyView" ref="788645002"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="35451329"/>
 						<reference key="NSHScroller" ref="420284366"/>
@@ -2426,8 +2382,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</object>
 				</array>
 				<string key="NSFrameSize">{389, 301}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="677707641"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
@@ -2648,6 +2602,31 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="64324442">
+						<reference key="NSNextResponder" ref="438687363"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="438687363"/>
+						<reference key="NSWindow"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="226569095">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="677502429"/>
+							<reference key="NSControlView" ref="64324442"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="364528377"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="40268269">
 						<reference key="NSNextResponder" ref="438687363"/>
 						<int key="NSvFlags">272</int>
@@ -2659,10 +2638,11 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 									<object class="NSOutlineView" id="1023504710">
 										<reference key="NSNextResponder" ref="899754174"/>
 										<int key="NSvFlags">256</int>
+										<array class="NSMutableArray" key="NSSubviews"/>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="899754174"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="818105254"/>
+										<reference key="NSNextKeyView" ref="171889341"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2766,21 +2746,21 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<object class="NSScroller" id="171889341">
 								<reference key="NSNextResponder" ref="40268269"/>
 								<int key="NSvFlags">-2147483392</int>
-								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
+								<string key="NSFrame">{{1, 230}, {351, 16}}</string>
 								<reference key="NSSuperview" ref="40268269"/>
 								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="260815785"/>
+								<reference key="NSNextKeyView" ref="818105254"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="40268269"/>
 								<string key="NSAction">_doScroller:</string>
-								<double key="NSPercent">0.95726495981216431</double>
+								<double key="NSPercent">0.92612137203166223</double>
 							</object>
 						</array>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="438687363"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="171889341"/>
+						<reference key="NSNextKeyView" ref="260815785"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="260815785"/>
 						<reference key="NSHScroller" ref="171889341"/>
@@ -2825,6 +2805,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="438687363"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="64324442"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="857807288">
 							<int key="NSCellFlags">67108864</int>
@@ -2860,7 +2841,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSWindowTemplate" id="172003406">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{469, 551}, {241, 137}}</string>
+				<string key="NSWindowRect">{{469, 551}, {270, 181}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2872,20 +2853,21 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="1002322754">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<int key="NSvFlags">256</int>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="930227868">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {174, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {144, 17}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="533006433"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="354994507">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Enter name of new context</string>
+								<string key="NSContents">Enter name of context</string>
 								<reference key="NSSupport" ref="677502429"/>
 								<reference key="NSControlView" ref="930227868"/>
 								<reference key="NSBackgroundColor" ref="293801161"/>
@@ -2896,9 +2878,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSTextField" id="533006433">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {201, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
-							<reference key="NSNextKeyView" ref="794733565"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="547242046"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="215929726">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2915,8 +2898,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="912201430">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{145, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{174, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="720472985">
 								<int key="NSCellFlags">67108864</int>
@@ -2937,8 +2921,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="794733565">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{63, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{92, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="912201430"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="521376302">
@@ -2957,8 +2942,75 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="202147084">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="817835368"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="547242046">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="202147084"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="837462026">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="677502429"/>
+								<reference key="NSControlView" ref="547242046"/>
+								<reference key="NSBackgroundColor" ref="293801161"/>
+								<reference key="NSTextColor" ref="249372474"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="817835368">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="794733565"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="186324731">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="677502429"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="817835368"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="942080401"/>
+								<reference key="NSAlternateImage" ref="521638745"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrameSize">{241, 137}</string>
+					<string key="NSFrameSize">{270, 181}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="930227868"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
@@ -4868,6 +4920,46 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="202147084"/>
+					</object>
+					<int key="connectionID">2134</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="817835368"/>
+					</object>
+					<int key="connectionID">2135</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="202147084"/>
+					</object>
+					<int key="connectionID">2138</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="817835368"/>
+					</object>
+					<int key="connectionID">2139</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="64324442"/>
+					</object>
+					<int key="connectionID">2148</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="35176552"/>
@@ -5054,6 +5146,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">2106</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="64324442"/>
+						<reference key="destination" ref="57763103"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="64324442"/>
+							<reference key="NSDestination" ref="57763103"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">2147</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5840,6 +5952,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="40268269"/>
 							<reference ref="818105254"/>
 							<reference ref="252521227"/>
+							<reference ref="64324442"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5915,9 +6028,12 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="1002322754"/>
 						<array class="NSMutableArray" key="children">
 							<reference ref="930227868"/>
-							<reference ref="533006433"/>
+							<reference ref="547242046"/>
+							<reference ref="817835368"/>
+							<reference ref="202147084"/>
 							<reference ref="912201430"/>
 							<reference ref="794733565"/>
+							<reference ref="533006433"/>
 						</array>
 						<reference key="parent" ref="172003406"/>
 					</object>
@@ -6960,6 +7076,50 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="216659969"/>
 						<reference key="parent" ref="348936883"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2107</int>
+						<reference key="object" ref="202147084"/>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2108</int>
+						<reference key="object" ref="547242046"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="837462026"/>
+						</array>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2109</int>
+						<reference key="object" ref="837462026"/>
+						<reference key="parent" ref="547242046"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2132</int>
+						<reference key="object" ref="817835368"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="186324731"/>
+						</array>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2133</int>
+						<reference key="object" ref="186324731"/>
+						<reference key="parent" ref="817835368"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2140</int>
+						<reference key="object" ref="64324442"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="226569095"/>
+						</array>
+						<reference key="parent" ref="438687363"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2141</int>
+						<reference key="object" ref="226569095"/>
+						<reference key="parent" ref="64324442"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7246,6 +7406,13 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="2049.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2059.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2060.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2107.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2108.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2109.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2132.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2133.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2140.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2141.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7304,7 +7471,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">2106</int>
+			<int key="maxID">2159</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7401,6 +7568,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7409,6 +7578,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7550,7 +7727,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7588,10 +7764,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Resources/fr.lproj/MainMenu.xib
+++ b/Resources/fr.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -768,7 +769,7 @@
 										<string key="NSFrameSize">{436, 198}</string>
 										<reference key="NSSuperview" ref="636682733"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="875202178"/>
+										<reference key="NSNextKeyView" ref="592256119"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1017,7 +1018,7 @@
 						<string key="NSFrame">{{20, 48}, {438, 216}}</string>
 						<reference key="NSSuperview" ref="382071677"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="636682733"/>
+						<reference key="NSNextKeyView" ref="875202178"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="354840670"/>
 						<reference key="NSHScroller" ref="592256119"/>
@@ -1092,6 +1093,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="382071677"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="579456243">
 							<int key="NSCellFlags">67108864</int>
@@ -1101,7 +1103,7 @@
 							<reference key="NSControlView" ref="541308524"/>
 							<int key="NSButtonFlags">-2033958912</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="806687380">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1842,6 +1844,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{18, 311}, {112, 18}}</string>
 						<reference key="NSSuperview" ref="928026043"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="209065629"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="834764842">
 							<int key="NSCellFlags">67108864</int>
@@ -1866,6 +1869,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{17, 317}, {431, 56}}</string>
 						<reference key="NSSuperview" ref="928026043"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="754798852"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1020384219">
 							<int key="NSCellFlags">67108864</int>
@@ -1892,6 +1896,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{13, 7}, {295, 18}}</string>
 										<reference key="NSSuperview" ref="913636353"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="1044768335"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="332156808">
 											<int key="NSCellFlags">67108864</int>
@@ -1916,6 +1921,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{16, 27}, {261, 17}}</string>
 										<reference key="NSSuperview" ref="913636353"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="311991573"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="710474621">
 											<int key="NSCellFlags">67108864</int>
@@ -1934,6 +1940,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{236, 27}, {110, 21}}</string>
 										<reference key="NSSuperview" ref="913636353"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="299205527"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="807101385">
 											<int key="NSCellFlags">67371264</int>
@@ -1960,6 +1967,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{349, 32}, {66, 13}}</string>
 										<reference key="NSSuperview" ref="913636353"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="327324583"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="200336045">
 											<int key="NSCellFlags">67108864</int>
@@ -1976,11 +1984,13 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 								<string key="NSFrame">{{2, 2}, {427, 57}}</string>
 								<reference key="NSSuperview" ref="209065629"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="365304395"/>
 							</object>
 						</array>
 						<string key="NSFrame">{{17, 246}, {431, 61}}</string>
 						<reference key="NSSuperview" ref="928026043"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="913636353"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
 							<int key="NSCellFlags">67108864</int>
@@ -2013,6 +2023,7 @@ d28gbGluZXMsIOKApioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrameSize">{423, 192}</string>
 										<reference key="NSSuperview" ref="822117640"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="406660816"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="212610450">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2105,6 +2116,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{408, 1}, {16, 192}}</string>
 								<reference key="NSSuperview" ref="1044768335"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="989020701"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="1044768335"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2116,6 +2128,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="1044768335"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="822117640"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="1044768335"/>
@@ -2127,7 +2140,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 194}}</string>
 						<reference key="NSSuperview" ref="928026043"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="822117640"/>
+						<reference key="NSNextKeyView" ref="796585407"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="406660816"/>
 						<reference key="NSHScroller" ref="796585407"/>
@@ -2143,6 +2156,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="928026043"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="316906086">
 							<int key="NSCellFlags">67108864</int>
@@ -2167,6 +2181,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{465, 388}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="326470779"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2216,6 +2231,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="919452854"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="18895864"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2225,6 +2241,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<string key="NSFrameSize">{347, 17}</string>
 											<reference key="NSSuperview" ref="87744040"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="919452854"/>
 											<reference key="NSTableView" ref="108783674"/>
 										</object>
 										<object class="_NSCornerView" key="NSCornerView">
@@ -2328,6 +2345,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="94593814"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="94593814"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2339,6 +2357,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, 244}, {347, 16}}</string>
 								<reference key="NSSuperview" ref="94593814"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="1035416078"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="94593814"/>
@@ -2363,7 +2382,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="703953326"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="919452854"/>
+						<reference key="NSNextKeyView" ref="87744040"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="1035416078"/>
 						<reference key="NSHScroller" ref="18895864"/>
@@ -2378,6 +2397,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{389, 301}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="94593814"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2594,6 +2614,32 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSCustomView" id="571100514">
 				<reference key="NSNextResponder"/>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="796854083">
+						<reference key="NSNextResponder" ref="571100514"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="571100514"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="841182898">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="806370697"/>
+							<reference key="NSControlView" ref="796854083"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="806687380"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="940251307">
 						<reference key="NSNextResponder" ref="571100514"/>
 						<int key="NSvFlags">272</int>
@@ -2608,6 +2654,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="796317626"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="358887203"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2702,6 +2749,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-30, 1}, {15, 245}}</string>
 								<reference key="NSSuperview" ref="940251307"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="796317626"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="940251307"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2713,6 +2761,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
 								<reference key="NSSuperview" ref="940251307"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="443610325"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="940251307"/>
@@ -2723,7 +2772,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="571100514"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="796317626"/>
+						<reference key="NSNextKeyView" ref="129236617"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="443610325"/>
 						<reference key="NSHScroller" ref="129236617"/>
@@ -2739,6 +2788,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="571100514"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="506551549"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="870850805">
 							<int key="NSCellFlags">67108864</int>
@@ -2767,6 +2817,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="571100514"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="796854083"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="993900127">
 							<int key="NSCellFlags">67108864</int>
@@ -2790,6 +2841,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{393, 315}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="940251307"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2801,7 +2853,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSWindowTemplate" id="632093066">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{216, 543}, {264, 127}}</string>
+				<string key="NSWindowRect">{{216, 543}, {271, 178}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2813,18 +2865,20 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="833186945">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="601144363">
 							<reference key="NSNextResponder" ref="833186945"/>
-							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 90}, {235, 17}}</string>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{17, 144}, {177, 17}}</string>
 							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="204596235"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="842711785">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Entrer le nom du nouveau contexte :</string>
+								<string key="NSContents">Entrer le nom du contexte :</string>
 								<reference key="NSSupport" ref="806370697"/>
 								<reference key="NSControlView" ref="601144363"/>
 								<reference key="NSBackgroundColor" ref="190950060"/>
@@ -2835,8 +2889,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSTextField" id="204596235">
 							<reference key="NSNextResponder" ref="833186945"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 60}, {224, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {231, 22}}</string>
 							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="789851291"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="391554907">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2853,8 +2909,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="920929985">
 							<reference key="NSNextResponder" ref="833186945"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{168, 12}, {82, 32}}</string>
+							<string key="NSFrame">{{175, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="798084134">
 								<int key="NSCellFlags">67108864</int>
@@ -2875,8 +2933,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="709927037">
 							<reference key="NSNextResponder" ref="833186945"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{78, 12}, {90, 32}}</string>
+							<string key="NSFrame">{{85, 13}, {90, 32}}</string>
 							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="920929985"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="376435911">
 								<int key="NSCellFlags">67108864</int>
@@ -2894,8 +2954,76 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="743182708">
+							<reference key="NSNextResponder" ref="833186945"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{228, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="616637073"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="789851291">
+							<reference key="NSNextResponder" ref="833186945"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{18, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="743182708"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="800210928">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="806370697"/>
+								<reference key="NSControlView" ref="789851291"/>
+								<reference key="NSBackgroundColor" ref="190950060"/>
+								<reference key="NSTextColor" ref="786413591"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="616637073">
+							<reference key="NSNextResponder" ref="833186945"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{19, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="833186945"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="709927037"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="798127060">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="806370697"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="616637073"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="546721011"/>
+								<reference key="NSAlternateImage" ref="823416216"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrameSize">{264, 127}</string>
+					<string key="NSFrameSize">{271, 178}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="601144363"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
 				<string key="NSMinSize">{213, 129}</string>
@@ -4789,6 +4917,46 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="29953154"/>
+						<reference key="destination" ref="743182708"/>
+					</object>
+					<int key="connectionID">1975</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="29953154"/>
+						<reference key="destination" ref="743182708"/>
+					</object>
+					<int key="connectionID">1977</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="29953154"/>
+						<reference key="destination" ref="616637073"/>
+					</object>
+					<int key="connectionID">1978</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="29953154"/>
+						<reference key="destination" ref="616637073"/>
+					</object>
+					<int key="connectionID">1979</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="29953154"/>
+						<reference key="destination" ref="796854083"/>
+					</object>
+					<int key="connectionID">1981</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="346685394"/>
@@ -4971,6 +5139,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">1955</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="796854083"/>
+						<reference key="destination" ref="29953154"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="796854083"/>
+							<reference key="NSDestination" ref="29953154"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1980</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5741,6 +5929,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="940251307"/>
 							<reference ref="358887203"/>
 							<reference ref="506551549"/>
+							<reference ref="796854083"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5819,6 +6008,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="204596235"/>
 							<reference ref="920929985"/>
 							<reference ref="709927037"/>
+							<reference ref="789851291"/>
+							<reference ref="616637073"/>
+							<reference ref="743182708"/>
 						</array>
 						<reference key="parent" ref="632093066"/>
 					</object>
@@ -6877,6 +7069,50 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="831015614"/>
 						<reference key="parent" ref="1051297816"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1956</int>
+						<reference key="object" ref="796854083"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="841182898"/>
+						</array>
+						<reference key="parent" ref="571100514"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1957</int>
+						<reference key="object" ref="841182898"/>
+						<reference key="parent" ref="796854083"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1968</int>
+						<reference key="object" ref="743182708"/>
+						<reference key="parent" ref="833186945"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1969</int>
+						<reference key="object" ref="789851291"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="800210928"/>
+						</array>
+						<reference key="parent" ref="833186945"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1970</int>
+						<reference key="object" ref="616637073"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="798127060"/>
+						</array>
+						<reference key="parent" ref="833186945"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1971</int>
+						<reference key="object" ref="798127060"/>
+						<reference key="parent" ref="616637073"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1972</int>
+						<reference key="object" ref="800210928"/>
+						<reference key="parent" ref="789851291"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7166,6 +7402,13 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="1939.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1956.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1957.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1968.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1969.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1970.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1971.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1972.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7213,7 +7456,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1955</int>
+			<int key="maxID">1981</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7310,6 +7553,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7318,6 +7563,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7441,7 +7694,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7479,10 +7731,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Resources/it.lproj/MainMenu.xib
+++ b/Resources/it.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -769,7 +770,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="83162100"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="1058842077"/>
+										<reference key="NSNextKeyView" ref="71445549"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1018,7 +1019,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="825060112"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="83162100"/>
+						<reference key="NSNextKeyView" ref="1058842077"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="3815011"/>
 						<reference key="NSHScroller" ref="71445549"/>
@@ -1093,6 +1094,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="825060112"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="661775016">
 							<int key="NSCellFlags">67108864</int>
@@ -1102,7 +1104,7 @@
 							<reference key="NSControlView" ref="972575921"/>
 							<int key="NSButtonFlags">-2033958912</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="780341147">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1841,6 +1843,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{18, 311}, {156, 18}}</string>
 						<reference key="NSSuperview" ref="452086995"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="202314985"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="432700542">
 							<int key="NSCellFlags">67108864</int>
@@ -1865,6 +1868,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 						<string key="NSFrame">{{17, 335}, {431, 34}}</string>
 						<reference key="NSSuperview" ref="452086995"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="726352178"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="983962570">
 							<int key="NSCellFlags">67108864</int>
@@ -1891,6 +1895,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{13, 7}, {397, 18}}</string>
 										<reference key="NSSuperview" ref="560620166"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="478330519"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="772537601">
 											<int key="NSCellFlags">67108864</int>
@@ -1915,6 +1920,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{16, 31}, {210, 13}}</string>
 										<reference key="NSSuperview" ref="560620166"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="706021785"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="730916821">
 											<int key="NSCellFlags">67108864</int>
@@ -1933,6 +1939,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{232, 27}, {110, 21}}</string>
 										<reference key="NSSuperview" ref="560620166"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="1062832501"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="160010255">
 											<int key="NSCellFlags">67371264</int>
@@ -1959,6 +1966,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrame">{{348, 31}, {63, 13}}</string>
 										<reference key="NSSuperview" ref="560620166"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="326440008"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="892327324">
 											<int key="NSCellFlags">67108864</int>
@@ -1975,11 +1983,13 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 								<string key="NSFrame">{{2, 2}, {427, 57}}</string>
 								<reference key="NSSuperview" ref="202314985"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="1030097810"/>
 							</object>
 						</array>
 						<string key="NSFrame">{{17, 246}, {431, 61}}</string>
 						<reference key="NSSuperview" ref="452086995"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="560620166"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
 							<int key="NSCellFlags">67108864</int>
@@ -2012,6 +2022,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrameSize">{423, 192}</string>
 										<reference key="NSSuperview" ref="318306809"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="634252025"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="354330524">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2104,6 +2115,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{408, 1}, {16, 192}}</string>
 								<reference key="NSSuperview" ref="478330519"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="342500950"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="478330519"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2115,6 +2127,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="478330519"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="318306809"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="478330519"/>
@@ -2126,7 +2139,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 194}}</string>
 						<reference key="NSSuperview" ref="452086995"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="318306809"/>
+						<reference key="NSNextKeyView" ref="588203763"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="634252025"/>
 						<reference key="NSHScroller" ref="588203763"/>
@@ -2141,6 +2154,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="452086995"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="1017402188">
 							<int key="NSCellFlags">67108864</int>
@@ -2165,6 +2179,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{465, 389}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="443405555"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2214,6 +2229,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="875729982"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="843974095"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2223,6 +2239,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<string key="NSFrameSize">{347, 17}</string>
 											<reference key="NSSuperview" ref="1020150565"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="875729982"/>
 											<reference key="NSTableView" ref="23926617"/>
 										</object>
 										<object class="_NSCornerView" key="NSCornerView">
@@ -2326,6 +2343,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="893519553"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="893519553"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2337,6 +2355,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, 244}, {347, 16}}</string>
 								<reference key="NSSuperview" ref="893519553"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="329110005"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="893519553"/>
@@ -2361,7 +2380,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="915600132"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="875729982"/>
+						<reference key="NSNextKeyView" ref="1020150565"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="329110005"/>
 						<reference key="NSHScroller" ref="843974095"/>
@@ -2376,6 +2395,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{389, 301}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="893519553"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2592,6 +2612,32 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSCustomView" id="192049717">
 				<reference key="NSNextResponder"/>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="371693271">
+						<reference key="NSNextResponder" ref="192049717"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="192049717"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="1002199692">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="563253970"/>
+							<reference key="NSControlView" ref="371693271"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="780341147"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="360297770">
 						<reference key="NSNextResponder" ref="192049717"/>
 						<int key="NSvFlags">272</int>
@@ -2606,6 +2652,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="243610023"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="714149378"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2700,6 +2747,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-30, 1}, {15, 245}}</string>
 								<reference key="NSSuperview" ref="360297770"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="243610023"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="360297770"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2711,6 +2759,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
 								<reference key="NSSuperview" ref="360297770"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="371649428"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="360297770"/>
@@ -2721,7 +2770,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="192049717"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="243610023"/>
+						<reference key="NSNextKeyView" ref="877861048"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="371649428"/>
 						<reference key="NSHScroller" ref="877861048"/>
@@ -2766,6 +2815,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="192049717"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="371693271"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="554323204">
 							<int key="NSCellFlags">67108864</int>
@@ -2789,6 +2839,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{393, 315}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="360297770"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2800,7 +2851,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSWindowTemplate" id="591253616">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{469, 551}, {241, 137}}</string>
+				<string key="NSWindowRect">{{469, 551}, {270, 178}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2812,18 +2863,20 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="719717357">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="954355738">
 							<reference key="NSNextResponder" ref="719717357"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {166, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {123, 17}}</string>
 							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="516135537"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="61447009">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Nome del nuovo contesto</string>
+								<string key="NSContents">Nome del contesto</string>
 								<reference key="NSSupport" ref="563253970"/>
 								<reference key="NSControlView" ref="954355738"/>
 								<reference key="NSBackgroundColor" ref="477702406"/>
@@ -2834,8 +2887,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSTextField" id="516135537">
 							<reference key="NSNextResponder" ref="719717357"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {201, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="948431840"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="12242084">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2849,11 +2904,78 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="1043980078">
+							<reference key="NSNextResponder" ref="719717357"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="417968343"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="948431840">
+							<reference key="NSNextResponder" ref="719717357"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="1043980078"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="735230528">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="563253970"/>
+								<reference key="NSControlView" ref="948431840"/>
+								<reference key="NSBackgroundColor" ref="477702406"/>
+								<reference key="NSTextColor" ref="931543260"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="417968343">
+							<reference key="NSNextResponder" ref="719717357"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="978281355"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="900885439">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="563253970"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="417968343"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="616436583"/>
+								<reference key="NSAlternateImage" ref="599443928"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 						<object class="NSButton" id="666124100">
 							<reference key="NSNextResponder" ref="719717357"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{145, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{174, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="804930708">
 								<int key="NSCellFlags">67108864</int>
@@ -2874,8 +2996,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="978281355">
 							<reference key="NSNextResponder" ref="719717357"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{60, 22}, {88, 32}}</string>
+							<string key="NSFrame">{{89, 13}, {88, 32}}</string>
 							<reference key="NSSuperview" ref="719717357"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="666124100"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="733831732">
 								<int key="NSCellFlags">67108864</int>
@@ -2894,7 +3018,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
 					</array>
-					<string key="NSFrame">{{1, 1}, {241, 137}}</string>
+					<string key="NSFrameSize">{270, 178}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="954355738"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
 				<string key="NSMinSize">{213, 129}</string>
@@ -4804,6 +4931,46 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="368644144"/>
+						<reference key="destination" ref="371693271"/>
+					</object>
+					<int key="connectionID">1942</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="368644144"/>
+						<reference key="destination" ref="1043980078"/>
+					</object>
+					<int key="connectionID">1948</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="368644144"/>
+						<reference key="destination" ref="417968343"/>
+					</object>
+					<int key="connectionID">1949</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="368644144"/>
+						<reference key="destination" ref="1043980078"/>
+					</object>
+					<int key="connectionID">1950</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="368644144"/>
+						<reference key="destination" ref="417968343"/>
+					</object>
+					<int key="connectionID">1951</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="188357014"/>
@@ -4970,6 +5137,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">1932</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="371693271"/>
+						<reference key="destination" ref="368644144"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="371693271"/>
+							<reference key="NSDestination" ref="368644144"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1941</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5764,6 +5951,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="360297770"/>
 							<reference ref="714149378"/>
 							<reference ref="60837184"/>
+							<reference ref="371693271"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5840,6 +6028,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<array class="NSMutableArray" key="children">
 							<reference ref="954355738"/>
 							<reference ref="516135537"/>
+							<reference ref="1043980078"/>
+							<reference ref="948431840"/>
+							<reference ref="417968343"/>
 							<reference ref="666124100"/>
 							<reference ref="978281355"/>
 						</array>
@@ -6876,6 +7067,50 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="592464980"/>
 						<reference key="parent" ref="151477662"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1933</int>
+						<reference key="object" ref="371693271"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="1002199692"/>
+						</array>
+						<reference key="parent" ref="192049717"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1934</int>
+						<reference key="object" ref="1002199692"/>
+						<reference key="parent" ref="371693271"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1943</int>
+						<reference key="object" ref="1043980078"/>
+						<reference key="parent" ref="719717357"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1944</int>
+						<reference key="object" ref="948431840"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="735230528"/>
+						</array>
+						<reference key="parent" ref="719717357"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1945</int>
+						<reference key="object" ref="417968343"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="900885439"/>
+						</array>
+						<reference key="parent" ref="719717357"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1946</int>
+						<reference key="object" ref="900885439"/>
+						<reference key="parent" ref="417968343"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1947</int>
+						<reference key="object" ref="735230528"/>
+						<reference key="parent" ref="948431840"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7162,6 +7397,13 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="1916.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1921.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1922.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1933.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1934.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1946.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1947.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7209,7 +7451,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1932</int>
+			<int key="maxID">1951</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7306,6 +7548,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7314,6 +7558,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7437,7 +7689,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7475,10 +7726,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Resources/pt-BR.lproj/MainMenu.xib
+++ b/Resources/pt-BR.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -769,7 +770,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="648544117"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="440226565"/>
+										<reference key="NSNextKeyView" ref="752042160"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1018,7 +1019,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="280217310"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="648544117"/>
+						<reference key="NSNextKeyView" ref="440226565"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="609388239"/>
 						<reference key="NSHScroller" ref="752042160"/>
@@ -1093,6 +1094,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="280217310"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="502912008">
 							<int key="NSCellFlags">67108864</int>
@@ -1102,7 +1104,7 @@
 							<reference key="NSControlView" ref="699475917"/>
 							<int key="NSButtonFlags">-2033958912</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="1010722049">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -1840,6 +1842,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 						<string key="NSFrame">{{18, 311}, {125, 18}}</string>
 						<reference key="NSSuperview" ref="657063169"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="676093712"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="17707087">
 							<int key="NSCellFlags">67108864</int>
@@ -1864,6 +1867,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 						<string key="NSFrame">{{17, 335}, {431, 34}}</string>
 						<reference key="NSSuperview" ref="657063169"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="958002289"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="92904408">
 							<int key="NSCellFlags">67108864</int>
@@ -1890,6 +1894,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 										<string key="NSFrame">{{13, 7}, {399, 18}}</string>
 										<reference key="NSSuperview" ref="932233505"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="1023417149"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSButtonCell" key="NSCell" id="456256591">
 											<int key="NSCellFlags">67108864</int>
@@ -1914,6 +1919,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 										<string key="NSFrame">{{2, 31}, {224, 13}}</string>
 										<reference key="NSSuperview" ref="932233505"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="173669622"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="482543118">
 											<int key="NSCellFlags">67108864</int>
@@ -1932,6 +1938,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 										<string key="NSFrame">{{232, 27}, {110, 21}}</string>
 										<reference key="NSSuperview" ref="932233505"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="983893548"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSSliderCell" key="NSCell" id="493131501">
 											<int key="NSCellFlags">67371264</int>
@@ -1958,6 +1965,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 										<string key="NSFrame">{{348, 31}, {67, 13}}</string>
 										<reference key="NSSuperview" ref="932233505"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="599584939"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="948730173">
 											<int key="NSCellFlags">67108864</int>
@@ -1974,11 +1982,13 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 								<string key="NSFrame">{{2, 2}, {427, 57}}</string>
 								<reference key="NSSuperview" ref="676093712"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="61606996"/>
 							</object>
 						</array>
 						<string key="NSFrame">{{17, 246}, {431, 61}}</string>
 						<reference key="NSSuperview" ref="657063169"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="932233505"/>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
 							<int key="NSCellFlags">67108864</int>
@@ -2011,6 +2021,7 @@ cyBkdWFzIGxpbmhhcywgLi4uKgoqbWFzIGFjZWl0YSBhdMOpIHRyw6pzLio</string>
 										<string key="NSFrameSize">{423, 192}</string>
 										<reference key="NSSuperview" ref="1034519373"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="953575645"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="665192259">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2103,6 +2114,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{408, 1}, {16, 192}}</string>
 								<reference key="NSSuperview" ref="1023417149"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="184447995"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="1023417149"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2114,6 +2126,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
 								<reference key="NSSuperview" ref="1023417149"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="1034519373"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="1023417149"/>
@@ -2125,7 +2138,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 194}}</string>
 						<reference key="NSSuperview" ref="657063169"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="1034519373"/>
+						<reference key="NSNextKeyView" ref="12320911"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="953575645"/>
 						<reference key="NSHScroller" ref="12320911"/>
@@ -2140,6 +2153,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="657063169"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="598378917">
 							<int key="NSCellFlags">67108864</int>
@@ -2164,6 +2178,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{465, 389}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="28011835"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2213,6 +2228,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="522208486"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="763039279"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2222,6 +2238,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 											<string key="NSFrameSize">{347, 17}</string>
 											<reference key="NSSuperview" ref="622775297"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="522208486"/>
 											<reference key="NSTableView" ref="707406196"/>
 										</object>
 										<object class="_NSCornerView" key="NSCornerView">
@@ -2325,6 +2342,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="903143614"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="903143614"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2336,6 +2354,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, 244}, {347, 16}}</string>
 								<reference key="NSSuperview" ref="903143614"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="33095627"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="903143614"/>
@@ -2360,7 +2379,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="633730542"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="522208486"/>
+						<reference key="NSNextKeyView" ref="622775297"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="33095627"/>
 						<reference key="NSHScroller" ref="763039279"/>
@@ -2375,6 +2394,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{389, 301}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="903143614"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2591,6 +2611,32 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSCustomView" id="108770519">
 				<reference key="NSNextResponder"/>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="724393432">
+						<reference key="NSNextResponder" ref="108770519"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="108770519"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="562009318">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="614567188"/>
+							<reference key="NSControlView" ref="724393432"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="1010722049"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="524661052">
 						<reference key="NSNextResponder" ref="108770519"/>
 						<int key="NSvFlags">272</int>
@@ -2605,6 +2651,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="781773012"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="234090889"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2699,6 +2746,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{-30, 1}, {15, 245}}</string>
 								<reference key="NSSuperview" ref="524661052"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="781773012"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="524661052"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2710,6 +2758,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{1, -30}, {336, 15}}</string>
 								<reference key="NSSuperview" ref="524661052"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="49645892"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="524661052"/>
@@ -2720,7 +2769,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="108770519"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="781773012"/>
+						<reference key="NSNextKeyView" ref="661604834"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="49645892"/>
 						<reference key="NSHScroller" ref="661604834"/>
@@ -2765,6 +2814,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="108770519"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="724393432"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="414678700">
 							<int key="NSCellFlags">67108864</int>
@@ -2788,6 +2838,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="NSFrameSize">{393, 315}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="524661052"/>
 				<object class="NSMutableString" key="NSClassName">
 					<characters key="NS.bytes">NSView</characters>
 				</object>
@@ -2799,7 +2850,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSWindowTemplate" id="1045649624">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{469, 551}, {241, 137}}</string>
+				<string key="NSWindowRect">{{469, 551}, {270, 178}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2811,18 +2862,20 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="221591553">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="615679483">
 							<reference key="NSNextResponder" ref="221591553"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {209, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {174, 17}}</string>
 							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="756298376"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="636301882">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Digite o nome do novo contexto</string>
+								<string key="NSContents">Digite o nome do contexto</string>
 								<reference key="NSSupport" ref="614567188"/>
 								<reference key="NSControlView" ref="615679483"/>
 								<reference key="NSBackgroundColor" ref="804124283"/>
@@ -2833,8 +2886,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSTextField" id="756298376">
 							<reference key="NSNextResponder" ref="221591553"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {201, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="1029940739"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="231295738">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2851,8 +2906,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="844365850">
 							<reference key="NSNextResponder" ref="221591553"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{145, 22}, {82, 32}}</string>
+							<string key="NSFrame">{{174, 13}, {82, 32}}</string>
 							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="593231942">
 								<int key="NSCellFlags">67108864</int>
@@ -2873,8 +2930,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="249343854">
 							<reference key="NSNextResponder" ref="221591553"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{50, 22}, {95, 32}}</string>
+							<string key="NSFrame">{{79, 13}, {95, 32}}</string>
 							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="844365850"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="1001900390">
 								<int key="NSCellFlags">67108864</int>
@@ -2892,8 +2951,76 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="510119220">
+							<reference key="NSNextResponder" ref="221591553"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="300198530"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="1029940739">
+							<reference key="NSNextResponder" ref="221591553"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="510119220"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="557869137">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="614567188"/>
+								<reference key="NSControlView" ref="1029940739"/>
+								<reference key="NSBackgroundColor" ref="804124283"/>
+								<reference key="NSTextColor" ref="741632344"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="300198530">
+							<reference key="NSNextResponder" ref="221591553"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="221591553"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="249343854"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="12064363">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="614567188"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="300198530"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="584308461"/>
+								<reference key="NSAlternateImage" ref="390065401"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrame">{{1, 1}, {241, 137}}</string>
+					<string key="NSFrameSize">{270, 178}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="615679483"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
 				<string key="NSMinSize">{213, 129}</string>
@@ -4803,6 +4930,46 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="138871468"/>
+						<reference key="destination" ref="724393432"/>
+					</object>
+					<int key="connectionID">1940</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="138871468"/>
+						<reference key="destination" ref="510119220"/>
+					</object>
+					<int key="connectionID">1946</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="138871468"/>
+						<reference key="destination" ref="300198530"/>
+					</object>
+					<int key="connectionID">1947</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="138871468"/>
+						<reference key="destination" ref="510119220"/>
+					</object>
+					<int key="connectionID">1948</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="138871468"/>
+						<reference key="destination" ref="300198530"/>
+					</object>
+					<int key="connectionID">1949</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="461932819"/>
@@ -4969,6 +5136,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">1934</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="724393432"/>
+						<reference key="destination" ref="138871468"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="724393432"/>
+							<reference key="NSDestination" ref="138871468"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">1939</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5763,6 +5950,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="524661052"/>
 							<reference ref="234090889"/>
 							<reference ref="786279692"/>
+							<reference ref="724393432"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5841,6 +6029,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="756298376"/>
 							<reference ref="844365850"/>
 							<reference ref="249343854"/>
+							<reference ref="510119220"/>
+							<reference ref="1029940739"/>
+							<reference ref="300198530"/>
 						</array>
 						<reference key="parent" ref="1045649624"/>
 					</object>
@@ -6875,6 +7066,50 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="69926628"/>
 						<reference key="parent" ref="240804664"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1935</int>
+						<reference key="object" ref="724393432"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="562009318"/>
+						</array>
+						<reference key="parent" ref="108770519"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1936</int>
+						<reference key="object" ref="562009318"/>
+						<reference key="parent" ref="724393432"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1941</int>
+						<reference key="object" ref="510119220"/>
+						<reference key="parent" ref="221591553"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1942</int>
+						<reference key="object" ref="1029940739"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="557869137"/>
+						</array>
+						<reference key="parent" ref="221591553"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1943</int>
+						<reference key="object" ref="300198530"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="12064363"/>
+						</array>
+						<reference key="parent" ref="221591553"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1944</int>
+						<reference key="object" ref="12064363"/>
+						<reference key="parent" ref="300198530"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1945</int>
+						<reference key="object" ref="557869137"/>
+						<reference key="parent" ref="1029940739"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7161,6 +7396,13 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="1917.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1924.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1925.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1935.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1936.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1941.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1942.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="1945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7208,7 +7450,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">1934</int>
+			<int key="maxID">1949</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7305,6 +7547,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7313,6 +7557,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7436,7 +7688,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7474,10 +7725,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Resources/pt-PT.lproj/MainMenu.xib
+++ b/Resources/pt-PT.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
 			<string>NSBox</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
+			<string>NSColorWell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSMenu</string>
@@ -761,7 +762,7 @@
 										<string key="NSFrameSize">{435, 198}</string>
 										<reference key="NSSuperview" ref="916458113"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="217639070"/>
+										<reference key="NSNextKeyView" ref="729802760"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1010,7 +1011,7 @@
 						<string key="NSFrame">{{20, 48}, {437, 216}}</string>
 						<reference key="NSSuperview" ref="273226987"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="916458113"/>
+						<reference key="NSNextKeyView" ref="217639070"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="439280017"/>
 						<reference key="NSHScroller" ref="729802760"/>
@@ -1085,6 +1086,7 @@
 						<string key="NSFrame">{{67, 19}, {25, 22}}</string>
 						<reference key="NSSuperview" ref="273226987"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="338340382">
 							<int key="NSCellFlags">67108864</int>
@@ -1094,7 +1096,7 @@
 							<reference key="NSControlView" ref="657012302"/>
 							<int key="NSButtonFlags">-2033434624</int>
 							<int key="NSButtonFlags2">34</int>
-							<object class="NSCustomResource" key="NSNormalImage">
+							<object class="NSCustomResource" key="NSNormalImage" id="541687467">
 								<string key="NSClassName">NSImage</string>
 								<string key="NSResourceName">gear</string>
 							</object>
@@ -2028,7 +2030,7 @@ d28gbGluZXMsIC4uLioKKmJ1dCBpdCBtYXkgc3BhbiB0aHJlZS4qA</string>
 										<string key="NSFrameSize">{423, 192}</string>
 										<reference key="NSSuperview" ref="690402953"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="302758342"/>
+										<reference key="NSNextKeyView" ref="345876992"/>
 										<object class="NSTextContainer" key="NSTextContainer" id="584820345">
 											<object class="NSLayoutManager" key="NSLayoutManager">
 												<object class="NSTextStorage" key="NSTextStorage">
@@ -2145,7 +2147,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {425, 194}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="690402953"/>
+						<reference key="NSNextKeyView" ref="302758342"/>
 						<int key="NSsFlags">133138</int>
 						<reference key="NSVScroller" ref="345876992"/>
 						<reference key="NSHScroller" ref="302758342"/>
@@ -2160,6 +2162,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="588395791"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="762195779">
 							<int key="NSCellFlags">67108864</int>
@@ -2235,7 +2238,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{347, 243}</string>
 										<reference key="NSSuperview" ref="788645002"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="983622499"/>
+										<reference key="NSNextKeyView" ref="420284366"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2349,6 +2352,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 								<string key="NSFrame">{{332, 17}, {16, 243}}</string>
 								<reference key="NSSuperview" ref="677707641"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<reference key="NSTarget" ref="677707641"/>
 								<string key="NSAction">_doScroller:</string>
@@ -2385,7 +2389,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 20}, {349, 261}}</string>
 						<reference key="NSSuperview" ref="830434413"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="788645002"/>
+						<reference key="NSNextKeyView" ref="983622499"/>
 						<int key="NSsFlags">133170</int>
 						<reference key="NSVScroller" ref="35451329"/>
 						<reference key="NSHScroller" ref="420284366"/>
@@ -2627,6 +2631,32 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="1067858997">
+						<reference key="NSNextResponder" ref="438687363"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{58, 19}, {25, 22}}</string>
+						<reference key="NSSuperview" ref="438687363"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="464796649">
+							<int key="NSCellFlags">67108864</int>
+							<int key="NSCellFlags2">134217728</int>
+							<string key="NSContents"/>
+							<reference key="NSSupport" ref="677502429"/>
+							<reference key="NSControlView" ref="1067858997"/>
+							<int key="NSButtonFlags">-2033434624</int>
+							<int key="NSButtonFlags2">34</int>
+							<reference key="NSNormalImage" ref="541687467"/>
+							<string key="NSAlternateContents"/>
+							<object class="NSMutableString" key="NSKeyEquivalent">
+								<characters key="NS.bytes"/>
+							</object>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSScrollView" id="40268269">
 						<reference key="NSNextResponder" ref="438687363"/>
 						<int key="NSvFlags">272</int>
@@ -2641,7 +2671,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 										<string key="NSFrameSize">{351, 245}</string>
 										<reference key="NSSuperview" ref="899754174"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="171889341"/>
+										<reference key="NSNextKeyView" ref="818105254"/>
 										<bool key="NSEnabled">YES</bool>
 										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 										<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -2759,7 +2789,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{20, 48}, {353, 247}}</string>
 						<reference key="NSSuperview" ref="438687363"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="899754174"/>
+						<reference key="NSNextKeyView" ref="171889341"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="260815785"/>
 						<reference key="NSHScroller" ref="171889341"/>
@@ -2804,6 +2834,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="NSFrame">{{39, 19}, {20, 22}}</string>
 						<reference key="NSSuperview" ref="438687363"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1067858997"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="857807288">
 							<int key="NSCellFlags">67108864</int>
@@ -2839,7 +2870,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<object class="NSWindowTemplate" id="172003406">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{469, 551}, {300, 137}}</string>
+				<string key="NSWindowRect">{{469, 551}, {270, 181}}</string>
 				<int key="NSWTFlags">1886912512</int>
 				<string key="NSWindowTitle">*New Context*</string>
 				<object class="NSMutableString" key="NSWindowClass">
@@ -2851,20 +2882,21 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<string key="NSWindowContentMinSize">{213, 107}</string>
 				<object class="NSView" key="NSWindowView" id="1002322754">
-					<nil key="NSNextResponder"/>
+					<reference key="NSNextResponder"/>
 					<int key="NSvFlags">256</int>
 					<array class="NSMutableArray" key="NSSubviews">
 						<object class="NSTextField" id="930227868">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{17, 100}, {266, 17}}</string>
+							<string key="NSFrame">{{17, 144}, {236, 17}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="533006433"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="354994507">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">272629760</int>
-								<string key="NSContents">Introduza o nome do novo contexto</string>
+								<string key="NSContents">Introduza o nome do contexto</string>
 								<reference key="NSSupport" ref="677502429"/>
 								<reference key="NSControlView" ref="930227868"/>
 								<reference key="NSBackgroundColor" ref="293801161"/>
@@ -2875,9 +2907,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSTextField" id="533006433">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{20, 70}, {260, 22}}</string>
+							<string key="NSFrame">{{20, 114}, {230, 22}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
-							<reference key="NSNextKeyView" ref="794733565"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="194414497"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="215929726">
 								<int key="NSCellFlags">-1804599231</int>
@@ -2894,8 +2927,10 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="912201430">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{191, 22}, {95, 32}}</string>
+							<string key="NSFrame">{{161, 13}, {95, 32}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="720472985">
 								<int key="NSCellFlags">67108864</int>
@@ -2916,8 +2951,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="NSButton" id="794733565">
 							<reference key="NSNextResponder" ref="1002322754"/>
 							<int key="NSvFlags">256</int>
-							<string key="NSFrame">{{96, 22}, {95, 32}}</string>
+							<string key="NSFrame">{{66, 13}, {95, 32}}</string>
 							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="912201430"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="521376302">
@@ -2936,8 +2972,75 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
+						<object class="NSColorWell" id="405290468">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>NSColor pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{227, 83}, {23, 23}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="382621905"/>
+							<string key="NSReuseIdentifierKey">_NS:1116</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSIsBordered">YES</bool>
+							<object class="NSColor" key="NSColor">
+								<int key="NSColorSpace">1</int>
+								<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
+							</object>
+						</object>
+						<object class="NSTextField" id="194414497">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">256</int>
+							<string key="NSFrame">{{17, 86}, {185, 17}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="405290468"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="61408947">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string key="NSContents">Pick color for status bar icon</string>
+								<reference key="NSSupport" ref="677502429"/>
+								<reference key="NSControlView" ref="194414497"/>
+								<reference key="NSBackgroundColor" ref="293801161"/>
+								<reference key="NSTextColor" ref="249372474"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSButton" id="382621905">
+							<reference key="NSNextResponder" ref="1002322754"/>
+							<int key="NSvFlags">264</int>
+							<string key="NSFrame">{{18, 59}, {234, 18}}</string>
+							<reference key="NSSuperview" ref="1002322754"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="794733565"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="134348820">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Preview picked color in status bar</string>
+								<reference key="NSSupport" ref="677502429"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="382621905"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="942080401"/>
+								<reference key="NSAlternateImage" ref="521638745"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrameSize">{300, 137}</string>
+					<string key="NSFrameSize">{270, 181}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="930227868"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
@@ -4827,6 +4930,46 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					<int key="connectionID">1689</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">editSelectedContext:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="1067858997"/>
+					</object>
+					<int key="connectionID">2073</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onIconColorChange:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="405290468"/>
+					</object>
+					<int key="connectionID">2079</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">onColorPreviewModeChange:</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="382621905"/>
+					</object>
+					<int key="connectionID">2080</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColor</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="405290468"/>
+					</object>
+					<int key="connectionID">2081</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">newContextSheetColorPreviewEnabled</string>
+						<reference key="source" ref="57763103"/>
+						<reference key="destination" ref="382621905"/>
+					</object>
+					<int key="connectionID">2082</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
 						<string key="label">selectedObject: selection.context</string>
 						<reference key="source" ref="35176552"/>
@@ -5029,6 +5172,26 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						</object>
 					</object>
 					<int key="connectionID">2067</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">enabled: selection</string>
+						<reference key="source" ref="1067858997"/>
+						<reference key="destination" ref="57763103"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="1067858997"/>
+							<reference key="NSDestination" ref="57763103"/>
+							<string key="NSLabel">enabled: selection</string>
+							<string key="NSBinding">enabled</string>
+							<string key="NSKeyPath">selection</string>
+							<object class="NSDictionary" key="NSOptions">
+								<string key="NS.key.0">NSValueTransformerName</string>
+								<string key="NS.object.0">NSIsNotNil</string>
+							</object>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">2072</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -5815,6 +5978,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 							<reference ref="40268269"/>
 							<reference ref="818105254"/>
 							<reference ref="252521227"/>
+							<reference ref="1067858997"/>
 						</array>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">ContextsPrefs</string>
@@ -5891,6 +6055,9 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<array class="NSMutableArray" key="children">
 							<reference ref="930227868"/>
 							<reference ref="533006433"/>
+							<reference ref="405290468"/>
+							<reference ref="194414497"/>
+							<reference ref="382621905"/>
 							<reference ref="912201430"/>
 							<reference ref="794733565"/>
 						</array>
@@ -6935,6 +7102,50 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<reference key="object" ref="856175393"/>
 						<reference key="parent" ref="259067236"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2068</int>
+						<reference key="object" ref="1067858997"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="464796649"/>
+						</array>
+						<reference key="parent" ref="438687363"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2069</int>
+						<reference key="object" ref="464796649"/>
+						<reference key="parent" ref="1067858997"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2074</int>
+						<reference key="object" ref="405290468"/>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2075</int>
+						<reference key="object" ref="194414497"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="61408947"/>
+						</array>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2076</int>
+						<reference key="object" ref="382621905"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="134348820"/>
+						</array>
+						<reference key="parent" ref="1002322754"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2077</int>
+						<reference key="object" ref="134348820"/>
+						<reference key="parent" ref="382621905"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2078</int>
+						<reference key="object" ref="61408947"/>
+						<reference key="parent" ref="194414497"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -7221,6 +7432,13 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 				<string key="2049.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2057.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2058.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2068.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2069.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2074.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2075.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2076.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2077.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="2078.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="231.CustomClassName">DNDArrayController</string>
 				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -7277,7 +7495,7 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">2067</int>
+			<int key="maxID">2082</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7374,6 +7592,8 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="newContextSheet">NSPanel</string>
+						<string key="newContextSheetColor">NSColorWell</string>
+						<string key="newContextSheetColorPreviewEnabled">NSButton</string>
 						<string key="newContextSheetName">NSTextField</string>
 						<string key="outlineView">NSOutlineView</string>
 						<string key="prefsWindow">NSWindow</string>
@@ -7382,6 +7602,14 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="newContextSheet">
 							<string key="name">newContextSheet</string>
 							<string key="candidateClassName">NSPanel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColor">
+							<string key="name">newContextSheetColor</string>
+							<string key="candidateClassName">NSColorWell</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="newContextSheetColorPreviewEnabled">
+							<string key="name">newContextSheetColorPreviewEnabled</string>
+							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="newContextSheetName">
 							<string key="name">newContextSheetName</string>
@@ -7523,7 +7751,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<string key="advancedPrefsView">NSView</string>
 						<string key="contextsDataSource">ContextsDataSource</string>
 						<string key="contextsPrefsView">NSView</string>
-						<string key="cpController">CPController</string>
 						<string key="defaultContextButton">ContextSelectionButton</string>
 						<string key="editActionContextButton">ContextSelectionButton</string>
 						<string key="evidenceSources">EvidenceSourceSetController</string>
@@ -7561,10 +7788,6 @@ AAEAAQAAAT0AAwAAAAEAAgAAAVIAAwAAAAEAAQAAAVMAAwAAAAIAAQABAAAAAA</bytes>
 						<object class="IBToOneOutletInfo" key="contextsPrefsView">
 							<string key="name">contextsPrefsView</string>
 							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="cpController">
-							<string key="name">cpController</string>
-							<string key="candidateClassName">CPController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="defaultContextButton">
 							<string key="name">defaultContextButton</string>

--- a/Source/CPController.h
+++ b/Source/CPController.h
@@ -19,6 +19,7 @@
 	NSTimer *sbHideTimer;
 
 	NSString *currentContextUUID, *currentContextName;
+    NSColor *currentColorOfIcon;
 	NSInteger smoothCounter;
 
 	IBOutlet NSMenuItem *forceContextMenuItem;

--- a/Source/CPController.m
+++ b/Source/CPController.m
@@ -14,6 +14,7 @@
 #import "NSTimer+Invalidation.h"
 #import "CPNotifications.h"
 #import <libkern/OSAtomic.h>
+#import <QuartzCore/QuartzCore.h>
 
 
 @interface CPController (Private)
@@ -159,9 +160,28 @@
     
 }
 
+- (NSImage *)getImageFromImage:(NSImage*)img byAddingBiasColor:(NSColor *)color {
+    CIImage *inputImage = [[[CIImage alloc] initWithData:[img TIFFRepresentation]] autorelease];
+
+    NSColor *rgb = [color colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+    CIVector *bias = [CIVector vectorWithX:[rgb redComponent] Y:[rgb greenComponent] Z:[rgb blueComponent]];
+
+    CIFilter *filter = [CIFilter filterWithName:@"CIColorMatrix"];
+    [filter setDefaults];
+    [filter setValue:inputImage forKey:kCIInputImageKey];
+    [filter setValue:bias forKey:@"inputBiasVector"];
+
+    CIImage *outputImage = [filter valueForKey:kCIOutputImageKey];
+    
+    NSImage *resultImage = [[[NSImage alloc] initWithSize:img.size] autorelease];
+    NSCIImageRep *rep = [NSCIImageRep imageRepWithCIImage:outputImage];
+    [resultImage addRepresentation:rep];
+    
+    return resultImage;
+}
+
 // Helper: Load a named image, and scale it to be suitable for menu bar use.
-- (NSImage *)prepareImageForMenubar:(NSString *)name
-{
+- (NSImage *)prepareImageForMenubar:(NSString *)name {
 	NSImage *img = [NSImage imageNamed:name];
 	[img setScalesWhenResized:YES];
     // TODO: provide images for retina displays
@@ -171,11 +191,10 @@
 }
 
 - (id)init {
-	if (!(self = [super init])) {
+	if (!(self = [super init]))
 		return nil;
-    }
 
-	sbImageActive = [[self prepareImageForMenubar:@"cp-icon-active"] retain];
+	sbImageActive   = [[self prepareImageForMenubar:@"cp-icon-active"]   retain];
 	sbImageInactive = [[self prepareImageForMenubar:@"cp-icon-inactive"] retain];
 	sbItem = nil;
 	sbHideTimer = nil;
@@ -208,10 +227,10 @@
 
 - (void)dealloc {
     [_rules release];
-    
-    [sbImageInactive release];
+
     [sbImageActive release];
-    
+    [sbImageInactive release];
+
     [numberFormatter release];
 	[updatingSwitchingLock release];
 	[updatingLock release];
@@ -457,6 +476,7 @@
 		if (ctxt) {
 			[self setValue:uuid forKey:@"currentContextUUID"];
 			[self setValue:[contextsDataSource pathFromRootTo:uuid] forKey:@"currentContextName"];
+            [self setValue:[ctxt iconColor] forKey:@"currentColorOfIcon"];
 
 			// Update force context menu
 			NSMenu *menu = [forceContextMenuItem submenu];
@@ -586,6 +606,15 @@
 											 selector:@selector(unsetStickyBit:)
 												 name:@"unsetStickyBit"
 											   object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateMenuBarImageOnIconColorPreviewNotification:)
+                                                 name:@"iconColorPreviewRequested"
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateMenuBarImageOnIconColorPreviewNotification:)
+                                                 name:@"iconColorPreviewFinished"
+                                               object:nil];
 }
 
 
@@ -608,6 +637,20 @@
     [as release];
 }
 
+- (void)updateMenuBarImageOnIconColorPreviewNotification:(NSNotification *)notification {
+    NSDictionary *userInfo = [notification userInfo];
+    if (userInfo) {
+        NSColor *color = userInfo[@"color"];
+        if (color) {
+            [self setMenuBarImage:[self getImageFromImage:sbImageActive byAddingBiasColor:color]];
+        } else {
+            [self setMenuBarImage:sbImageActive];
+        }
+    } else {
+        [self updateMenuBarImage];
+    }
+}
+
 - (void)updateMenuBarImage {
 	if (!sbItem) {
 		return;
@@ -615,7 +658,15 @@
 
     NSImage *barImage = nil;
     if ([[NSUserDefaults standardUserDefaults] floatForKey:@"menuBarOption"] != CP_DISPLAY_CONTEXT) {
-        barImage = ([currentContextUUID length] > 0) ? (sbImageActive) : (sbImageInactive);
+        if ([currentContextUUID length] > 0) {
+            barImage = sbImageActive;
+
+            if (currentColorOfIcon && ![currentColorOfIcon isEqualTo:[NSColor blackColor]]) {
+                barImage = [self getImageFromImage:barImage byAddingBiasColor:currentColorOfIcon];
+            }
+        } else {
+            barImage = sbImageInactive;
+        }
     }
 
     [self setMenuBarImage:barImage];
@@ -707,8 +758,8 @@
 	for (Context *ctxt in [contextsDataSource orderedTraversal]) {
 		NSMenuItem *item = [[[NSMenuItem alloc] init] autorelease];
 		[item setTitle:[ctxt name]];
-		[item setIndentationLevel:[[ctxt valueForKey:@"depth"] intValue]];
-		[item setRepresentedObject:[ctxt uuid]];
+		[item setIndentationLevel:[ctxt.depth intValue]];
+		[item setRepresentedObject:ctxt.uuid];
 		[item setTarget:self];
 		[item setAction:@selector(forceSwitch:)];
 		[submenu addItem:item];
@@ -739,10 +790,12 @@
 	Context *ctxt = [contextsDataSource contextByUUID:currentContextUUID];
 	if (ctxt) {
 		[self setValue:[contextsDataSource pathFromRootTo:currentContextUUID] forKey:@"currentContextName"];
+        [self setValue:[ctxt iconColor] forKey:@"currentColorOfIcon"];
 	} else {
 		// Our current context was removed
 		[self setValue:@""  forKey:@"currentContextUUID"];
 		[self setValue:@"?" forKey:@"currentContextName"];
+        [self setValue:nil forKey:@"currentColorOfIcon"];
 	}
 
     // Update menu bar (always do that in the main thread)
@@ -1076,6 +1129,9 @@
 	[self setValue:toUUID forKey:@"currentContextUUID"];
 	[self setValue:ctxt_path forKey:@"currentContextName"];
 
+    Context *toCtxt = enteringWalk[[enteringWalk count] - 1];
+    [self setValue:[toCtxt iconColor] forKey:@"currentColorOfIcon"];
+
     // Notify subscribed apps
     NSDictionary *userInfo = @{ @"context": ctxt_path };
     [dnc postNotificationName:notificationName object:notificationObject userInfo:userInfo deliverImmediately:YES];
@@ -1252,7 +1308,7 @@
 		if ([currentContextTree count] == 0)
 			continue;	// Oops, something got busted along the way
 
-		const int base_depth = [[currentContextTree[0] valueForKey:@"depth"] intValue];
+		const int base_depth = [((Context *) currentContextTree[0]).depth intValue];
         const double currentRuleConfidence = [currentRule[@"confidence"] doubleValue];
 
 		for (Context *currentContext in currentContextTree) {
@@ -1267,7 +1323,7 @@
             }
 
             // account for the amount of confidence this matching rule affects the guess
-			const int depth = [[currentContext valueForKey:@"depth"] intValue];
+			const int depth = [currentContext.depth intValue];
 			double mult = 1.0 - (0.03 * (depth - base_depth)); // decay
 			mult *= currentRuleConfidence;
 			unconfidenceValue = @([unconfidenceValue doubleValue] * (1.0 - mult));
@@ -1331,18 +1387,17 @@
     // Update the values seen in the GUI.  This shows that there are rules that match
     // the context and what the "confidence" is for each
     for (NSString *uuid in allConfiguredContexts) {
-		NSNumber *conf = guesses[uuid];
-		NSString *newConfString = (conf) ? ([numberFormatter stringFromNumber:conf]) : (@"");
-
 		Context *ctxt = [contextsDataSource contextByUUID:uuid];
-		[ctxt setValue:newConfString forKey:@"confidence"];
+		NSNumber *conf = guesses[uuid];
+        ctxt.confidence = (conf) ? ([numberFormatter stringFromNumber:conf]) : (@"");
 	}
 
 	// XXX: hackish -- but will be enough until 3.0
     // don't force data update if we're editing a context name
 	NSOutlineView *olv = [contextsDataSource valueForKey:@"outlineView"];
-	if (![olv currentEditor])
+	if (![olv currentEditor]) {
         [contextsDataSource triggerOutlineViewReloadData:nil];
+    }
 }
 
 - (NSString *)getGuessConfidenceStringFrom:(NSNumber *)confidence {

--- a/Source/ContextsDataSource.h
+++ b/Source/ContextsDataSource.h
@@ -6,15 +6,17 @@
 //
 
 
-@interface Context : NSObject {
-	NSString *uuid;
-	NSString *parent;	// UUID
-	NSString *name;
+@interface Context : NSObject
 
-	// Transient
-	NSNumber *depth;
-	NSString *confidence;
-}
+// Persistent
+@property (assign,nonatomic,readonly) NSString *uuid;
+@property (copy,nonatomic,readwrite) NSString *parentUUID;
+@property (copy,nonatomic,readwrite) NSString *name;
+@property (copy,nonatomic,readwrite) NSColor  *iconColor;
+
+// Transient
+@property (copy,nonatomic,readwrite) NSString *confidence;
+@property (retain,nonatomic,readonly) NSNumber *depth;
 
 - (id)init;
 - (id)initWithDictionary:(NSDictionary *)dict;
@@ -22,12 +24,6 @@
 - (BOOL)isRoot;
 - (NSDictionary *)dictionary;
 - (NSComparisonResult)compare:(Context *)ctxt;
-
-- (NSString *)uuid;
-- (NSString *)parentUUID;
-- (void)setParentUUID:(NSString *)parentUUID;
-- (NSString *)name;
-- (void)setName:(NSString *)newName;
 
 @end
 
@@ -40,8 +36,11 @@
 	Context *selection;
 
 	IBOutlet NSWindow *prefsWindow;
+
 	IBOutlet NSPanel *newContextSheet;
 	IBOutlet NSTextField *newContextSheetName;
+    IBOutlet NSColorWell *newContextSheetColor;
+    IBOutlet NSButton *newContextSheetColorPreviewEnabled;
 }
 
 - (void)loadContexts;

--- a/Source/PrefsWindowController.h
+++ b/Source/PrefsWindowController.h
@@ -14,8 +14,6 @@
 	NSToolbar *prefsToolbar;
 
     
-
-	IBOutlet CPController *cpController;
 	IBOutlet EvidenceSourceSetController *evidenceSources;
 	IBOutlet ContextsDataSource *contextsDataSource;
 	IBOutlet NSArrayController *rulesController, *actionsController;

--- a/Source/PrefsWindowController.m
+++ b/Source/PrefsWindowController.m
@@ -61,11 +61,11 @@
 	double res;
 
 	if (!value || [value isEqualToString:NSLocalizedString(@"None", @"Delay value to display for zero seconds")])
-		res = 0;
+		res = 0.0;
 	else
 		res = [value doubleValue];
 
-	return [NSNumber numberWithDouble:res];
+	return @(res);
 }
 
 @end
@@ -174,8 +174,7 @@
                     forName:@"RuleStatusResultTransformer"];
 }
 
-- (id)init
-{
+- (id)init {
 	if (!(self = [super init]))
 		return nil;
 
@@ -183,7 +182,7 @@
 
 	newActionWindowParameterViewCurrentControl = nil;
 
-	[self setValue:[NSNumber numberWithBool:NO] forKey:@"logBufferPaused"];
+	[self setValue:@NO forKey:@"logBufferPaused"];
 	logBufferTimer = nil;
     
     _logBufferUnchangedSince = [[NSDate distantPast] retain];


### PR DESCRIPTION
Hi guys,

This is an experimental extension to ControlPlane that allows to change the color of the status bar icon depending on the active context. That is, the user can pick a color for the status bar icon for a context and when that context is selected according to the rules, the status bar icon color will change accordingly. I think this can be of specific interest to those CP users who prefer icon-only mode for status bar, but would still love to have a simple way to see (from the app icon) which context is active at the moment.

I like it and hope it will be embraced by other people as well. Anyways, let me know if you like it too. Or find it useless. Or have some specific objections to using non-black icon for CP, or using icon color for this specific purpose.

To highlight: I will need help from non-English speakers to properly localize the context edit panel for their specific languages.

Once again, I would like to ask all team members who are able and are willing to build from sources ahead of official releases, to try this extension themselves and share some feedback on it.

P.S. The code changes also include some clean-up and re-factoring to the code, as usual. This time, those are mostly in **ContextsDataSource**.
