### PR TITLE
Allow 'current context' to work in AppleScript when multiple contexts are enabled

### DIFF
--- a/Source/AppleScript.m
+++ b/Source/AppleScript.m
@@ -14,7 +14,7 @@
 // current context property
 
 - (NSString *) currentContext {
-	return [[NSApp delegate] currentContextPath];
+	return [[NSApp delegate] currentContextAsString];
 }
 
 - (void) setCurrentContext: (NSString*) newContext {

--- a/Source/CPController.h
+++ b/Source/CPController.h
@@ -41,6 +41,8 @@
 - (void)resumeRegularUpdates;
 - (void)resumeRegularUpdatesWithDelay:(int64_t)nanoseconds;
 - (void)forceUpdate;
+
+- (NSString*)currentContextAsString;
 + (NSSet *) sharedActiveContexts;
 
 @end

--- a/Source/CPController.m
+++ b/Source/CPController.m
@@ -773,9 +773,7 @@ static NSSet *sharedActiveContexts = nil;
                 [_joinedContextPaths appendString:context.name]; //[contextsDataSource pathFromRootTo:context.uuid]];
              }
              self.currentContextPath=_joinedContextPaths;*/
-            NSSortDescriptor *sortKey=[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:TRUE];
-            NSArray *keyArray=[NSArray arrayWithObject:sortKey];
-            self.currentContextPath=[[self.activeContexts sortedArrayUsingDescriptors:keyArray] componentsJoinedByString:@" + "]; // sans context-paths, to conserve space. perhaps we'll add a pref to switch it on (above).
+            self.currentContextPath=[self currentContextAsString];
         }
         [self setStatusTitle:[self currentContextPath]];
     }
@@ -1966,6 +1964,18 @@ const int64_t UPDATING_TIMER_LEEWAY = (int64_t) (0.5 * NSEC_PER_SEC);
             
         default:
             break;
+    }
+}
+
+- (NSString*) currentContextAsString {
+    if ([self useMultipleActiveContexts]) {
+        NSSortDescriptor *sortKey=[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:TRUE];
+        NSArray *keyArray=[NSArray arrayWithObject:sortKey];
+        NSArray* aca = [self.activeContexts sortedArrayUsingDescriptors:keyArray];
+        NSString* acas = [aca componentsJoinedByString:@" + "];
+        return acas;
+    } else {
+        return self.currentContextPath;
     }
 }
 @end


### PR DESCRIPTION
Created a `currentContextAsString` method in `CPController`. This is called by `current context` in Applescript, and will either return the `currentContextPath` (the current behavior) or will join the active contexts into a big string.
The method uses the code from `updateMenuBarAndContextMenu`, and I refactored that method to call the new one.

Fixes #325, fixes #323
