### PR TITLE
minor: fix odd English in log

### DIFF
--- a/Source/ShellScriptAction.m
+++ b/Source/ShellScriptAction.m
@@ -125,7 +125,7 @@
             return;
         }
         
-        DSLog(@"Finished to execute '%@'", pathCopy);
+        DSLog(@"Finished executing '%@'", pathCopy);
     };
     
     [task launch];


### PR DESCRIPTION
I saw the string "Finished to execute" which is some strange English, so here is a patch to fix it.
