### PR TITLE
support overnight TimeOfDay rules

### DIFF
--- a/Source/TimeOfDayEvidenceSource.m
+++ b/Source/TimeOfDayEvidenceSource.m
@@ -152,6 +152,9 @@
 	if (![self parseParameter:[rule valueForKey:@"parameter"] intoDay:&day startTime:&startT endTime:&endT])
 		return NO;
 
+	if ([startT earlierDate:endT] == endT)  //cross-midnight rule
+		endT = [endT dateByAddingTimeInterval:(24 * 60 * 60)]; // +24 hours
+		
 	// Check day first
 	NSInteger dow = [now dayOfWeek];	// 0=Sunday, 1=Monday, etc.
 	if ([day isEqualToString:@"Any day"]) {


### PR DESCRIPTION
When the user sets up a TimeOfDay rule that crosses midnight, we need to add a day to the end-time so that NSDate comparisons work correctly during rule match. The hour & minute components of that end time are not altered and the DayOfWeek checks will still apply.
