### PR TITLE
remove debug NSLog()s

### DIFF
--- a/Source/CPController.m
+++ b/Source/CPController.m
@@ -200,14 +200,11 @@ static NSSet *sharedActiveContexts = nil;
         sharedActiveContexts = [NSSet set];
     }
     
-    NSLog(@"%@", sharedActiveContexts);
-    
     return sharedActiveContexts;
 }
 
 + (void) setSharedActiveContexts:(NSSet *) newActiveContexts {
     sharedActiveContexts = newActiveContexts;
-    NSLog(@"%@", sharedActiveContexts);
     return;
 }
 


### PR DESCRIPTION
These NSLog()s were firing on every rule-check interval when ContextEvidenceSource was enabled.
Fixes #350
