### PR TITLE
Fix for issue #362: Crash with shell script rule

### DIFF
--- a/Source/ShellScriptEvidenceSource.m
+++ b/Source/ShellScriptEvidenceSource.m
@@ -195,7 +195,7 @@
     NSMutableArray *shebangArgs = [scriptName interpreterFromFile];
 	if (shebangArgs && [shebangArgs count] > 0) {
 		// get interpreter
-		interpreter = [shebangArgs objectAtIndex: 0];
+		interpreter = [[[shebangArgs objectAtIndex: 0] retain] autorelease];
 		[shebangArgs removeObjectAtIndex: 0];
 		
 		// and it's parameters


### PR DESCRIPTION
Fixed use-after-release of the "interpreter" variable that was
causing a crash when shell scripts were executed.  The value of
the variable was being retrieved from shebangArgs without being
retained, and then the object was removed from shebangArgs in the
next line, which released the value.
