### PR TITLE
Crash fix for Bad_access on sleep

### DIFF
--- a/Source/CPController.m
+++ b/Source/CPController.m
@@ -970,7 +970,7 @@ static NSSet *sharedActiveContexts = nil;
 // a new thread
 - (void)doExecuteAction:(Action *)action {
 	@autoreleasepool {
-        NSString *errorString;
+        NSString *errorString = nil;
         BOOL success = [action execute:&errorString];
         [self decreaseActionsInProgress];
 


### PR DESCRIPTION
Fix the crash when the computer goes to sleep.
I know it probably didn't need a pull request but I wanted to see how to do it for the future. 