### PR TITLE
Finish replacing locks with @synchronized

### DIFF
--- a/Source/RunningApplicationEvidenceSource.h
+++ b/Source/RunningApplicationEvidenceSource.h
@@ -9,7 +9,6 @@
 
 
 @interface RunningApplicationEvidenceSource : GenericEvidenceSource {
-	NSLock *lock;
 	NSMutableArray *applications;
 }
 


### PR DESCRIPTION
I was seeing occasional crashes in `RunningApplicationEvidenceSource`, where an `NSMutableArray` was being mutated while being iterated over. It looks like  51b3c215cf5f067b66357a7ff43792b24497e601 was meant to replace the lock with `@synchronized`, but it didn't happen throughout the entire file (also, the `lock` member was never initialized). I finished converting the NSLocks to @synchronized, and I haven't seen this crash since.