### PR TITLE
Fix forcing of discrete GPU under Sierra

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -113,6 +113,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>OSAScriptingDefinition</key>
 	<string>ControlPlane.sdef</string>
 	<key>SMPrivilegedExecutables</key>


### PR DESCRIPTION
Updated info.plist to include NSSupportsAutomaticGraphicsSwitching, so that macOS Sierra doesn’t use only discrete graphics when ControlPlane is running.

This fixes issue [#456](https://github.com/dustinrue/ControlPlane/issues/456).