### PR TITLE
When lid is closed, light sensor returns max value

### DIFF
--- a/Source/LightEvidenceSource.m
+++ b/Source/LightEvidenceSource.m
@@ -86,11 +86,12 @@ enum {
 	// COMMENTS(jbeker) below is the observed max value on a 15" Late 2013 Macbook Pro
 	// This value is ridiculous and results in a much smaller
 	// useful value range.
-	const double kMaxLightValue = 4294967295.0;
+    const double kClosedLightValue = 4294967295.0;
+    const double kMaxLightValue = 67092480.0;;
 
     const double avg = (left + right) / 2; // determine average value from the two sensors
     
-    if (avg == kMaxLightValue) {
+    if (avg == kClosedLightValue) {
         return 0; // COMMENTS(jbeker) on a 15" Late 2013 Macbook Pro it returns max value when the laptop is shut
     } else {
         return (avg / kMaxLightValue); // normalize

--- a/Source/LightEvidenceSource.m
+++ b/Source/LightEvidenceSource.m
@@ -83,13 +83,18 @@ enum {
 // Returns value in [0.0, 1.0]
 - (double)levelFromRawLeft:(uint64_t)left andRight:(uint64_t)right {
 	// FIXME(rdamazio): This value is probably incorrect
-	// COMMENTS(dustinrue) below is the observed max value on a 13" unibody MacBook (Late 2008)
+	// COMMENTS(jbeker) below is the observed max value on a 15" Late 2013 Macbook Pro
 	// This value is ridiculous and results in a much smaller
 	// useful value range.
-	const double kMaxLightValue = 67092480.0;
+	const double kMaxLightValue = 4294967295.0;
 
     const double avg = (left + right) / 2; // determine average value from the two sensors
-	return (avg / kMaxLightValue); // normalize
+    
+    if (avg == kMaxLightValue) {
+        return 0; // COMMENTS(jbeker) on a 15" Late 2013 Macbook Pro it returns max value when the laptop is shut
+    } else {
+        return (avg / kMaxLightValue); // normalize
+    }
 }
 
 - (void)doUpdate {


### PR DESCRIPTION
I reported this as a bug #504 before realizing this was open source and I could fix it myself :)

If the lid is closed (on a Macbook Pro late 2013), the light sensors both report the max value. In that case, we really want to say the value is 0, so return that.

Happy to make changes if this is not an acceptable solution. I don't have any other laptops to test on unfortunately.