### PR TITLE
Multiplicative confidence model, rule negation, and sensor poll-loop optimizations

### DIFF
--- a/Sources/ControlPlaneApp/AppDatabase.swift
+++ b/Sources/ControlPlaneApp/AppDatabase.swift
@@ -124,6 +124,13 @@ final class AppDatabase {
             }
         }
 
+        migrator.registerMigration("v6_rule_negation") { db in
+            // Add the negate flag to existing rules; defaults to false (no change in behaviour).
+            try db.alter(table: "rules") { t in
+                t.add(column: "negate", .boolean).notNull().defaults(to: false)
+            }
+        }
+
         try migrator.migrate(dbQueue)
     }
 

--- a/Sources/ControlPlaneApp/RuleEngine.swift
+++ b/Sources/ControlPlaneApp/RuleEngine.swift
@@ -31,6 +31,17 @@ actor RuleEngine {
     // MARK: - Evaluation
 
     /// Re-evaluate all rules against the provided snapshots and update `currentActiveProfiles`.
+    ///
+    /// Confidence is computed using a multiplicative inverse (unconfidence) model:
+    ///
+    ///     unconfidence = ∏(1 − weight)  for each matching rule
+    ///     profile confidence = 1 − unconfidence
+    ///
+    /// This mirrors the original ControlPlane algorithm. Two rules each with weight 0.6
+    /// produce combined confidence 1 − (0.4 × 0.4) = 0.84, rather than a raw sum of 1.2.
+    ///
+    /// Rules with `negate = true` have their raw match result inverted before contributing
+    /// to confidence: they match (and add weight) when the sensor condition is *absent*.
     @discardableResult
     func evaluate(snapshots: [SensorSnapshot]) async throws -> [ActiveProfile] {
         let rules = try await ruleStore.list()
@@ -39,9 +50,12 @@ actor RuleEngine {
         // Index snapshots by sensor ID for O(1) lookup.
         let snapshotIndex = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.sensorID, $0) })
 
-        // Accumulate confidence per profile ID, recording each rule's match result.
-        var confidence: [UUID: Double] = [:]
+        // Track "unconfidence" per profile (starts at 1.0 = fully unconfident).
+        // For each matching rule: unconfidence *= (1 − rule.weight)
+        // Final confidence = 1 − unconfidence
+        var unconfidence: [UUID: Double] = [:]
         var ruleMatches: [UUID: Bool] = [:]
+
         for rule in rules where rule.enabled {
             guard let snapshot = snapshotIndex[rule.sensorID] else { continue }
             let reading = snapshot.readings.first(where: { $0.key == rule.readingKey })?.value
@@ -51,17 +65,22 @@ actor RuleEngine {
                 continue
             }
 
-            let matched = evaluator.evaluate(reading: reading, operatorID: rule.operatorID, comparand: rule.comparand)
+            let rawMatch = evaluator.evaluate(reading: reading, operatorID: rule.operatorID, comparand: rule.comparand)
+            // Apply negation: a negated rule contributes when the condition is absent.
+            let matched = rule.negate ? !rawMatch : rawMatch
             ruleMatches[rule.id] = matched
+
             if matched {
-                confidence[rule.profileID, default: 0] += rule.weight
+                let current = unconfidence[rule.profileID, default: 1.0]
+                unconfidence[rule.profileID] = current * (1.0 - rule.weight)
             }
         }
         currentRuleMatches = ruleMatches
 
-        // Filter profiles that meet their threshold.
+        // Convert unconfidence → confidence and filter profiles that meet their threshold.
         let profileIndex = Dictionary(uniqueKeysWithValues: profiles.map { ($0.id, $0) })
-        let active = confidence.compactMap { (profileID, score) -> ActiveProfile? in
+        let active = unconfidence.compactMap { (profileID, unc) -> ActiveProfile? in
+            let score = 1.0 - unc
             guard let profile = profileIndex[profileID],
                   score >= profile.confidenceThreshold else { return nil }
             return ActiveProfile(profile: profile, confidence: score)

--- a/Sources/ControlPlaneApp/RuleStore.swift
+++ b/Sources/ControlPlaneApp/RuleStore.swift
@@ -20,7 +20,8 @@ actor RuleStore {
         operatorID: String,
         comparand: ObservationValue,
         evaluatorID: String = "com.controlplane.evaluator.basic",
-        weight: Double = 1.0
+        weight: Double = 1.0,
+        negate: Bool = false
     ) async throws -> Rule {
         let rule = Rule(
             name: name,
@@ -30,7 +31,8 @@ actor RuleStore {
             operatorID: operatorID,
             comparand: comparand,
             evaluatorID: evaluatorID,
-            weight: weight
+            weight: weight,
+            negate: negate
         )
         let record = RuleRecord(rule)
         try await db.dbQueue.write { db in
@@ -58,6 +60,7 @@ actor RuleStore {
         comparand: ObservationValue,
         evaluatorID: String,
         weight: Double,
+        negate: Bool,
         enabled: Bool
     ) async throws -> Rule {
         let existing = try await get(id)
@@ -71,6 +74,7 @@ actor RuleStore {
             comparand: comparand,
             evaluatorID: evaluatorID,
             weight: weight,
+            negate: negate,
             enabled: enabled,
             createdAt: existing.createdAt,
             updatedAt: Date()
@@ -126,6 +130,7 @@ private struct RuleRecord: Codable, FetchableRecord, PersistableRecord {
     var comparandValue: String
     var evaluatorId: String
     var weight: Double
+    var negate: Bool
     var enabled: Bool
     var createdAt: String
     var updatedAt: String
@@ -143,6 +148,7 @@ private struct RuleRecord: Codable, FetchableRecord, PersistableRecord {
         comparandValue = rule.comparand.valueString
         evaluatorId = rule.evaluatorID
         weight = rule.weight
+        negate = rule.negate
         enabled = rule.enabled
         createdAt = Self.iso.string(from: rule.createdAt)
         updatedAt = Self.iso.string(from: rule.updatedAt)
@@ -160,6 +166,7 @@ private struct RuleRecord: Codable, FetchableRecord, PersistableRecord {
             comparand: comparand,
             evaluatorID: evaluatorId,
             weight: weight,
+            negate: negate,
             enabled: enabled,
             createdAt: Self.iso.date(from: createdAt) ?? Date(),
             updatedAt: Self.iso.date(from: updatedAt) ?? Date()

--- a/Sources/ControlPlaneApp/XPCServiceHandler.swift
+++ b/Sources/ControlPlaneApp/XPCServiceHandler.swift
@@ -251,7 +251,8 @@ final class RequestHandler {
             operatorID:  req.operatorID,
             comparand:   req.comparand,
             evaluatorID: req.evaluatorID,
-            weight:      req.weight
+            weight:      req.weight,
+            negate:      req.negate
         )
         await backend.refreshDynamicSensorKeys()
         return try encoder.encode(rule)
@@ -268,6 +269,7 @@ final class RequestHandler {
             comparand:   req.comparand,
             evaluatorID: req.evaluatorID,
             weight:      req.weight,
+            negate:      req.negate,
             enabled:     req.enabled
         )
         await backend.refreshDynamicSensorKeys()

--- a/Sources/ControlPlaneSDK/Rule.swift
+++ b/Sources/ControlPlaneSDK/Rule.swift
@@ -45,9 +45,18 @@ public protocol EvaluatorPlugin: ControlPlanePlugin {
 
 /// A single condition that contributes confidence toward activating a profile.
 ///
-/// A profile can have many rules; each matching rule adds its `weight` to the
-/// profile's confidence score. When the score reaches the profile's
-/// `confidenceThreshold`, the profile becomes active.
+/// Confidence is combined across rules using a multiplicative inverse (unconfidence) model:
+///
+///     unconfidence = ∏(1 − weight)  for each matching rule
+///     profile confidence = 1 − unconfidence
+///
+/// This means two rules each with weight 0.6 produce combined confidence
+/// 1 − (0.4 × 0.4) = 0.84, reflecting how independent signals accumulate.
+///
+/// When `negate` is true the rule's raw match result is inverted before
+/// contributing to confidence — the rule "matches" when the underlying
+/// sensor condition is *absent*. This lets you express disqualifying
+/// conditions such as "corporate VPN is NOT connected".
 public struct Rule: Identifiable, Codable, Sendable, Equatable {
     public let id: UUID
     public var name: String
@@ -63,8 +72,13 @@ public struct Rule: Identifiable, Codable, Sendable, Equatable {
     public var comparand: ObservationValue
     /// Which evaluator plugin performs the comparison. Defaults to the built-in basic evaluator.
     public var evaluatorID: String
-    /// Confidence points added to the profile when this rule matches.
+    /// Confidence weight (0.0–1.0) contributed to the profile when this rule matches.
+    /// A weight of 1.0 means a single matching rule brings the profile to full confidence.
+    /// Lower values require additional matching rules to reach the profile's threshold.
     public var weight: Double
+    /// When true, the rule's match result is inverted: it contributes confidence
+    /// when the sensor condition is *not* met.
+    public var negate: Bool
     public var enabled: Bool
     public let createdAt: Date
     public var updatedAt: Date
@@ -79,6 +93,7 @@ public struct Rule: Identifiable, Codable, Sendable, Equatable {
         comparand: ObservationValue,
         evaluatorID: String = "com.controlplane.evaluator.basic",
         weight: Double = 1.0,
+        negate: Bool = false,
         enabled: Bool = true,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -92,6 +107,7 @@ public struct Rule: Identifiable, Codable, Sendable, Equatable {
         self.comparand = comparand
         self.evaluatorID = evaluatorID
         self.weight = weight
+        self.negate = negate
         self.enabled = enabled
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -109,6 +125,7 @@ public struct RuleCreateRequest: Codable, Sendable {
     public var comparand: ObservationValue
     public var evaluatorID: String
     public var weight: Double
+    public var negate: Bool
 
     public init(
         name: String,
@@ -118,7 +135,8 @@ public struct RuleCreateRequest: Codable, Sendable {
         operatorID: String,
         comparand: ObservationValue,
         evaluatorID: String = "com.controlplane.evaluator.basic",
-        weight: Double = 1.0
+        weight: Double = 1.0,
+        negate: Bool = false
     ) {
         self.name = name
         self.profileID = profileID
@@ -128,6 +146,7 @@ public struct RuleCreateRequest: Codable, Sendable {
         self.comparand = comparand
         self.evaluatorID = evaluatorID
         self.weight = weight
+        self.negate = negate
     }
 }
 
@@ -140,6 +159,7 @@ public struct RuleUpdateRequest: Codable, Sendable {
     public var comparand: ObservationValue
     public var evaluatorID: String
     public var weight: Double
+    public var negate: Bool
     public var enabled: Bool
 
     public init(
@@ -150,6 +170,7 @@ public struct RuleUpdateRequest: Codable, Sendable {
         comparand: ObservationValue,
         evaluatorID: String = "com.controlplane.evaluator.basic",
         weight: Double = 1.0,
+        negate: Bool = false,
         enabled: Bool = true
     ) {
         self.name = name
@@ -159,6 +180,7 @@ public struct RuleUpdateRequest: Codable, Sendable {
         self.comparand = comparand
         self.evaluatorID = evaluatorID
         self.weight = weight
+        self.negate = negate
         self.enabled = enabled
     }
 }

--- a/Sources/Sensors/Bluetooth/BluetoothSensor.swift
+++ b/Sources/Sensors/Bluetooth/BluetoothSensor.swift
@@ -2,14 +2,24 @@ import Foundation
 import IOBluetooth
 import ControlPlaneSDK
 
-public final class BluetoothSensor: BaseSensor {
+/// Sensor that observes Bluetooth hardware state using IOBluetooth.
+///
+/// Always emits: powered, devices, per-device MAC readings.
+/// Connect/disconnect notifications handle real-time updates for devices
+/// and device-presence keys. The 30-second poll loop (needed to catch
+/// power-state changes that notifications miss) only runs when at least
+/// one rule references a Bluetooth key. When no rules use this sensor
+/// the poll loop is stopped, eliminating unnecessary background wakeups.
+public final class BluetoothSensor: BaseSensor, DynamicKeySensor {
 
     public override var pluginIdentifier: String  { "com.controlplane.sensors.bluetooth" }
     public override var pluginDisplayName: String { "Bluetooth" }
 
     private var connectNotification: IOBluetoothUserNotification?
     private var deviceDisconnectNotifications: [IOBluetoothUserNotification] = []
+    private var initTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
+    private var monitoredKeys: Set<String> = []
 
     public override required init() {
         super.init()
@@ -23,8 +33,8 @@ public final class BluetoothSensor: BaseSensor {
     public override func start() async {
         // Defer the first IOBluetooth access by 2 seconds so the app is fully
         // running and the TCC permission dialog can be presented to the user.
-        // Subsequent updates happen on the 30-second poll cycle.
-        pollTask = Task { [weak self] in
+        // The poll loop is NOT started here — setMonitoredKeys drives that.
+        initTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard !Task.isCancelled, let self else { return }
             await MainActor.run {
@@ -34,15 +44,12 @@ public final class BluetoothSensor: BaseSensor {
                 )
             }
             self.refreshSnapshot()
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 30_000_000_000)
-                guard !Task.isCancelled else { return }
-                self.refreshSnapshot()
-            }
         }
     }
 
     public override func stop() async {
+        initTask?.cancel()
+        initTask = nil
         pollTask?.cancel()
         pollTask = nil
         await MainActor.run {
@@ -52,6 +59,34 @@ public final class BluetoothSensor: BaseSensor {
             deviceDisconnectNotifications.removeAll()
         }
         publishInactive()
+    }
+
+    // MARK: - DynamicKeySensor
+
+    /// Called by the backend after every rule change.
+    /// Starts the poll loop when any rule references a Bluetooth key;
+    /// stops it when no rules do.
+    public func setMonitoredKeys(_ keys: [String]) {
+        let wasMonitoring = !monitoredKeys.isEmpty
+        let nowMonitoring = !keys.isEmpty
+        monitoredKeys = Set(keys)
+
+        guard wasMonitoring != nowMonitoring else { return }
+
+        if nowMonitoring {
+            print("[BluetoothSensor] rules reference Bluetooth keys — starting poll loop")
+            pollTask = Task { [weak self] in
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 30_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    self?.refreshSnapshot()
+                }
+            }
+        } else {
+            print("[BluetoothSensor] no rules reference Bluetooth keys — stopping poll loop")
+            pollTask?.cancel()
+            pollTask = nil
+        }
     }
 
     @objc private func deviceConnected(_ notification: IOBluetoothUserNotification, device: IOBluetoothDevice) {

--- a/Sources/Sensors/WiFi/WiFiSensor.swift
+++ b/Sources/Sensors/WiFi/WiFiSensor.swift
@@ -6,24 +6,32 @@ import ControlPlaneSDK
 /// Sensor that observes the current Wi-Fi connection state using CoreWLAN.
 ///
 /// Always emits: connected, SSID, BSSID, RSSI, security type.
-/// Network scan (visible_networks): always runs when not connected; when connected,
-/// controlled by `scanWhileConnected` (default false).
+/// Network scan (visible_networks): only runs when a rule references the
+/// "visible_networks" reading key. The backend calls `setMonitoredKeys(_:)`
+/// after each rule change; if no rule uses "visible_networks" the scan loop
+/// is stopped entirely, eliminating unnecessary background wakeups.
+/// When scanning is active and the device is connected, `scanWhileConnected`
+/// controls whether scans continue (default false).
 ///
 /// SSID and BSSID require Location Services permission on macOS 10.15+. The sensor
 /// requests authorization automatically on start via CLLocationManager. If permission
 /// is denied, ssid/bssid are emitted as empty strings.
-public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushSensor {
+public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushSensor, DynamicKeySensor {
     public var pluginIdentifier: String { "com.controlplane.sensors.wifi" }
     public var pluginDisplayName: String { "Wi-Fi" }
     public var pluginVersion: String { "1.0.0" }
     public var pluginCategory: String { "sensor" }
 
     /// When false (default), network scanning is suppressed while connected.
-    /// Scanning always runs when not connected regardless of this flag.
+    /// Only relevant when scanning is active (i.e. a rule references visible_networks).
     public var scanWhileConnected: Bool = false
 
     /// Injected by SensorCoordinator. Called after every snapshot update.
     public var onSnapshotChanged: (@Sendable () -> Void)?
+
+    /// True only when at least one enabled rule references the "visible_networks" key.
+    /// Controlled by setMonitoredKeys(_:) — do not set directly.
+    private var scanEnabled: Bool = false
 
     private let client = CWWiFiClient.shared()
     private var interface: CWInterface?
@@ -57,7 +65,9 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
         requestLocationAuthorization()
         interface = client.interface()
         subscribeToEvents()
-        startScanLoop()
+        // Scan loop is NOT started here. It starts only when setMonitoredKeys(_:)
+        // is called with a key set that includes "visible_networks". This avoids
+        // unnecessary background wakeups when no rule uses that reading.
         refreshSnapshot()
     }
 
@@ -133,7 +143,35 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
         }
     }
 
+    // MARK: - DynamicKeySensor
+
+    /// Called by the backend after every rule change.
+    /// Starts the scan loop when any rule references "visible_networks";
+    /// stops it (and clears stale results) when no rule does.
+    public func setMonitoredKeys(_ keys: [String]) {
+        let needsScan = keys.contains("visible_networks")
+        guard needsScan != scanEnabled else { return }
+        scanEnabled = needsScan
+
+        if scanEnabled {
+            print("[WiFiSensor] visible_networks referenced by a rule — starting scan loop")
+            startScanLoop()
+        } else {
+            print("[WiFiSensor] no rules reference visible_networks — stopping scan loop")
+            scanTask?.cancel()
+            scanTask = nil
+            // Clear any stale scan results from the snapshot.
+            let changed = lock.withLock {
+                let had = !_visibleNetworks.isEmpty
+                _visibleNetworks = []
+                return had
+            }
+            if changed { refreshSnapshot() }
+        }
+    }
+
     private func runScanIfNeeded() async {
+        guard scanEnabled else { return }
         guard let iface = interface else { return }
         let connected = iface.serviceActive()
 

--- a/Sources/cpctl/RuleCommands.swift
+++ b/Sources/cpctl/RuleCommands.swift
@@ -58,10 +58,11 @@ struct RulesList: AsyncParsableCommand {
             return
         }
 
-        print("\(col("ID", 36))  \(col("NAME", 20))  \(col("SENSOR", 28))  \(col("KEY", 16))  \(col("OP", 10))  \(col("COMPARAND", 20))  WT    EN   MATCH")
-        print(String(repeating: "-", count: 160))
+        print("\(col("ID", 36))  \(col("NAME", 20))  \(col("SENSOR", 28))  \(col("KEY", 16))  \(col("OP", 10))  \(col("COMPARAND", 20))  WT    NEG  EN   MATCH")
+        print(String(repeating: "-", count: 168))
         for r in rules {
             let en    = r.enabled ? "yes" : "no"
+            let neg   = r.negate  ? "yes" : "no"
             let wt    = String(format: "%.1f", r.weight)
             let match: String
             if !r.enabled {
@@ -71,7 +72,7 @@ struct RulesList: AsyncParsableCommand {
             } else {
                 match = "?"   // not yet evaluated (backend just started)
             }
-            print("\(col(r.id.uuidString, 36))  \(col(r.name, 20))  \(col(r.sensorID, 28))  \(col(r.readingKey, 16))  \(col(r.operatorID, 10))  \(col(r.comparand.description, 20))  \(col(wt, 5)) \(col(en, 4)) \(match)")
+            print("\(col(r.id.uuidString, 36))  \(col(r.name, 20))  \(col(r.sensorID, 28))  \(col(r.readingKey, 16))  \(col(r.operatorID, 10))  \(col(r.comparand.description, 20))  \(col(wt, 5)) \(col(neg, 4)) \(col(en, 4)) \(match)")
         }
     }
 }
@@ -102,8 +103,11 @@ struct RulesAdd: AsyncParsableCommand {
     @Option(name: .long, help: "Rule display name (defaults to '<key> <op> <value>').")
     var name: String?
 
-    @Option(name: .long, help: "Confidence weight added when this rule matches (default 1.0).")
+    @Option(name: .long, help: "Confidence weight (0.0–1.0) added when this rule matches (default 1.0).")
     var weight: Double = 1.0
+
+    @Flag(name: .long, help: "Invert the match: rule contributes confidence when the condition is absent.")
+    var negate: Bool = false
 
     @Option(name: .long, help: "Evaluator plugin ID (default: com.controlplane.evaluator.basic).")
     var evaluator: String = "com.controlplane.evaluator.basic"
@@ -124,7 +128,8 @@ struct RulesAdd: AsyncParsableCommand {
             operatorID: op,
             comparand: comparand,
             evaluatorID: evaluator,
-            weight: weight
+            weight: weight,
+            negate: negate
         )
 
         if json {
@@ -180,7 +185,7 @@ struct RulesEnable: AsyncParsableCommand {
         _ = try await client.updateRule(
             id: uuid, name: r.name, sensorID: r.sensorID, readingKey: r.readingKey,
             operatorID: r.operatorID, comparand: r.comparand,
-            evaluatorID: r.evaluatorID, weight: r.weight, enabled: true
+            evaluatorID: r.evaluatorID, weight: r.weight, negate: r.negate, enabled: true
         )
         print("Rule \(id) enabled.")
     }
@@ -199,7 +204,7 @@ struct RulesDisable: AsyncParsableCommand {
         _ = try await client.updateRule(
             id: uuid, name: r.name, sensorID: r.sensorID, readingKey: r.readingKey,
             operatorID: r.operatorID, comparand: r.comparand,
-            evaluatorID: r.evaluatorID, weight: r.weight, enabled: false
+            evaluatorID: r.evaluatorID, weight: r.weight, negate: r.negate, enabled: false
         )
         print("Rule \(id) disabled.")
     }
@@ -282,6 +287,7 @@ private extension Rule {
         Comparand: \(comparand)
         Evaluator: \(evaluatorID)
         Weight:    \(weight)
+        Negate:    \(negate ? "yes" : "no")
         Enabled:   \(enabled ? "yes" : "no")
         Created:   \(df.string(from: createdAt))
         """

--- a/Sources/cpctl/XPCClient.swift
+++ b/Sources/cpctl/XPCClient.swift
@@ -147,12 +147,13 @@ final class XPCClient {
         operatorID: String,
         comparand: ObservationValue,
         evaluatorID: String = "com.controlplane.evaluator.basic",
-        weight: Double = 1.0
+        weight: Double = 1.0,
+        negate: Bool = false
     ) async throws -> Rule {
         let req = RuleCreateRequest(
             name: name, profileID: profileID, sensorID: sensorID,
             readingKey: readingKey, operatorID: operatorID, comparand: comparand,
-            evaluatorID: evaluatorID, weight: weight
+            evaluatorID: evaluatorID, weight: weight, negate: negate
         )
         return try await send(method: "ruleCreate", body: req)
     }
@@ -170,12 +171,13 @@ final class XPCClient {
         comparand: ObservationValue,
         evaluatorID: String,
         weight: Double,
+        negate: Bool,
         enabled: Bool
     ) async throws -> Rule {
         let req = RuleUpdateRequest(
             name: name, sensorID: sensorID, readingKey: readingKey,
             operatorID: operatorID, comparand: comparand,
-            evaluatorID: evaluatorID, weight: weight, enabled: enabled
+            evaluatorID: evaluatorID, weight: weight, negate: negate, enabled: enabled
         )
         return try await send(method: "ruleUpdate", string1: id.uuidString, body: req)
     }

--- a/docs/rules-engine.md
+++ b/docs/rules-engine.md
@@ -5,13 +5,32 @@
 ```
 Sensor snapshot → RuleEngine.evaluate()
   → for each profile:
-       confidence = Σ weight of each matching enabled rule
+       unconfidence = ∏(1 − weight)  for each matching enabled rule
+       confidence   = 1 − unconfidence
        if confidence >= profile.confidenceThreshold → candidate
   → ProfileActivationManager resolves candidates → active profiles → actions fire
 ```
 
 A **Rule** is a single condition. A profile can have many rules. Multiple matching
-rules are additive — their weights sum toward the profile's threshold.
+rules combine using a **multiplicative inverse (unconfidence) model** — the same
+algorithm as the original ControlPlane app.
+
+The intuition: each unmatched rule leaves some residual doubt. Matching rules
+eliminate doubt multiplicatively rather than summing weights, so two moderately
+confident signals together give higher combined confidence than either alone:
+
+```
+AC power rule  (weight 0.6) matches → unconfidence: 1.0 × 0.4 = 0.40
+Home WiFi rule (weight 0.7) matches → unconfidence: 0.4 × 0.3 = 0.12
+Final confidence = 1 − 0.12 = 0.88  →  profile threshold 0.75 → ACTIVE
+
+AC power alone: confidence = 1 − 0.4 = 0.60  →  below 0.75 → NOT active
+```
+
+A rule with `negate: true` has its raw evaluator result inverted before
+contributing to confidence — it "matches" (adds weight) when the underlying
+sensor condition is **absent**. Use this for disqualifying conditions:
+"corporate VPN is NOT connected".
 
 ---
 
@@ -29,7 +48,8 @@ struct Rule: Identifiable, Codable, Sendable, Equatable {
     let operatorID: String      // e.g. "equals"
     let comparand: ObservationValue
     let evaluatorID: String     // default: "com.controlplane.evaluator.basic"
-    let weight: Double          // confidence points added when matched (default 1.0)
+    let weight: Double          // confidence weight 0.0–1.0 (default 1.0)
+    let negate: Bool            // invert match result (default false)
     let enabled: Bool
     let createdAt: Date
     let updatedAt: Date
@@ -42,17 +62,17 @@ struct Rule: Identifiable, Codable, Sendable, Equatable {
 struct Profile: Identifiable, Codable, Sendable {
     let id: UUID
     let name: String
-    let confidenceThreshold: Double  // minimum Σ weight to activate (default 1.0)
+    let confidenceThreshold: Double  // minimum confidence to activate (default 1.0)
     // ...
 }
 ```
 
-### `EvaluatorPlugin` (`Sources/ControlPlaneSDK/PluginProtocols.swift`)
+### `EvaluatorPlugin` (`Sources/ControlPlaneSDK/Rule.swift`)
 
 ```swift
 public protocol EvaluatorPlugin: ControlPlanePlugin {
     func evaluate(reading: ObservationValue?,
-                  operator operatorID: String,
+                  operatorID: String,
                   comparand: ObservationValue) -> Bool
     func supportedOperators() -> [OperatorDescriptor]
 }
@@ -107,47 +127,56 @@ Evaluation loop:
 1. Fetch all enabled rules from `RuleStore`
 2. For each rule, find the snapshot for `rule.sensorID`
 3. Find the reading for `rule.readingKey` in that snapshot
-4. Look up `rule.evaluatorID` in `EvaluatorRegistry`; call `evaluate(reading:operator:comparand:)`
-5. Accumulate weight per `profileID`
-6. Fetch all profiles; filter to those where `confidence >= profile.confidenceThreshold`
-7. Return `[ActiveProfile]` to `ProfileActivationManager`
+4. Look up `rule.evaluatorID` in `EvaluatorRegistry`; call `evaluate(reading:operatorID:comparand:)`
+5. If `rule.negate` is true, invert the result
+6. If matched, multiply the profile's running unconfidence by `(1.0 − rule.weight)`
+7. After all rules: `confidence = 1.0 − unconfidence` per profile
+8. Fetch all profiles; filter to those where `confidence >= profile.confidenceThreshold`
+9. Return `[ActiveProfile]` to `ProfileActivationManager`
 
 ---
 
 ## Database schema
 
-### Migration v1 (initial)
+### Migration v1 — profiles
 
 ```sql
 CREATE TABLE profiles (
-    id                  TEXT PRIMARY KEY,
-    name                TEXT NOT NULL,
-    confidenceThreshold REAL NOT NULL DEFAULT 1.0,
-    exclusive           INTEGER NOT NULL DEFAULT 0,
-    parentId            TEXT REFERENCES profiles(id) ON DELETE SET NULL,
-    createdAt           TEXT NOT NULL,
-    updatedAt           TEXT NOT NULL
+    id        TEXT PRIMARY KEY,
+    name      TEXT NOT NULL,
+    parentId  TEXT REFERENCES profiles(id) ON DELETE SET NULL,
+    exclusive INTEGER NOT NULL DEFAULT 0,
+    createdAt TEXT NOT NULL,
+    updatedAt TEXT NOT NULL
 );
 ```
 
-### Migration v2 (rules)
+### Migration v2 — rules
 
 ```sql
+ALTER TABLE profiles ADD COLUMN confidenceThreshold REAL NOT NULL DEFAULT 1.0;
+
 CREATE TABLE rules (
-    id              TEXT PRIMARY KEY,
-    name            TEXT NOT NULL,
-    profileId       TEXT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
-    sensorId        TEXT NOT NULL,
-    readingKey      TEXT NOT NULL,
-    operator        TEXT NOT NULL,
-    comparandType   TEXT NOT NULL,   -- ObservationValue type tag
-    comparandValue  TEXT NOT NULL,   -- JSON-encoded inner value
-    evaluatorId     TEXT NOT NULL DEFAULT 'com.controlplane.evaluator.basic',
-    weight          REAL NOT NULL DEFAULT 1.0,
-    enabled         INTEGER NOT NULL DEFAULT 1,
-    createdAt       TEXT NOT NULL,
-    updatedAt       TEXT NOT NULL
+    id             TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    profileId      TEXT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    sensorId       TEXT NOT NULL,
+    readingKey     TEXT NOT NULL,
+    operatorId     TEXT NOT NULL,
+    comparandType  TEXT NOT NULL,   -- ObservationValue type tag
+    comparandValue TEXT NOT NULL,   -- serialised inner value
+    evaluatorId    TEXT NOT NULL DEFAULT 'com.controlplane.evaluator.basic',
+    weight         REAL NOT NULL DEFAULT 1.0,
+    enabled        INTEGER NOT NULL DEFAULT 1,
+    createdAt      TEXT NOT NULL,
+    updatedAt      TEXT NOT NULL
 );
+```
+
+### Migration v6 — rule negation
+
+```sql
+ALTER TABLE rules ADD COLUMN negate INTEGER NOT NULL DEFAULT 0;
 ```
 
 ---
@@ -155,7 +184,7 @@ CREATE TABLE rules (
 ## cpctl commands
 
 ```
-cpctl rules list [--profile <name|uuid>]   # shows match status (✓/✗) for each rule
+cpctl rules list [--profile <name|uuid>]   # shows match status (✓/✗) and negate flag
 cpctl rules add  --profile <name|uuid> \
                  --sensor <sensorID> \
                  --key <readingKey> \
@@ -163,6 +192,7 @@ cpctl rules add  --profile <name|uuid> \
                  --value <comparand> \
                  [--name <label>] \
                  [--weight <n>] \
+                 [--negate] \
                  [--evaluator <id>]
 cpctl rules delete <uuid> [--force]
 cpctl rules enable  <uuid>
@@ -174,10 +204,12 @@ cpctl evaluators list                      # operators per evaluator
 
 ---
 
-## Example
+## Examples
+
+### Single rule — full confidence
 
 ```bash
-# Activate "Home" profile when connected to home WiFi
+# One rule with default weight 1.0 → confidence 1.0 → meets default threshold 1.0
 cpctl profiles add "Home"
 cpctl rules add \
   --profile Home \
@@ -187,8 +219,37 @@ cpctl rules add \
   --value "MyHomeSSID" \
   --name "Home WiFi"
 
-# Verify
 cpctl profiles active
 # → CONFIDENCE  NAME   ID
 # → 1.00        Home   <uuid>
+```
+
+### Multiple weighted rules — require agreement
+
+```bash
+# Neither rule alone (0.6 or 0.7) meets the 0.75 threshold.
+# Both together: 1 − (0.4 × 0.3) = 0.88 → ACTIVE.
+cpctl profiles add "Work"
+cpctl profiles update Work --threshold 0.75
+
+cpctl rules add --profile Work \
+  --sensor com.controlplane.sensors.power \
+  --key source --op equals --value ac \
+  --name "On AC power" --weight 0.6
+
+cpctl rules add --profile Work \
+  --sensor com.controlplane.sensors.wifi \
+  --key ssid --op equals --value "CorpWiFi" \
+  --name "Work WiFi" --weight 0.7
+```
+
+### Negated rule — disqualifying condition
+
+```bash
+# Matches (adds weight) only when the VPN is NOT connected.
+cpctl rules add --profile Home \
+  --sensor com.controlplane.sensors.networklink \
+  --key utun0 --op equals --value true \
+  --name "No VPN" --weight 0.5 \
+  --negate
 ```


### PR DESCRIPTION
## Summary

- **Multiplicative confidence model**: Rule weights now compose multiplicatively rather than additively, producing a confidence value in [0, 1] that's more intuitive to reason about. See `docs/rules-engine.md` for the design.
- **Rule negation**: Rules can now be negated (`negate: true`), contributing confidence when their condition is *not* met.
- **WiFi scan-loop optimization**: `WiFiSensor` conforms to `DynamicKeySensor`. The 30-second network scan loop now only runs when at least one enabled rule references the `visible_networks` reading key. No rules → no scans, eliminating unnecessary background wakeups.
- **Bluetooth poll-loop optimization**: `BluetoothSensor` conforms to `DynamicKeySensor` with the same pattern. The 30-second poll loop (needed only as a safety net for power-state changes that IOBluetooth notifications miss) now only runs when at least one rule references a Bluetooth key.

## What a reviewer should know

- `refreshDynamicSensorKeys()` in `Backend.swift` already calls `setMonitoredKeys(_:)` on all `DynamicKeySensor`s after every rule change and on startup — no backend changes were needed for the Bluetooth optimization.
- The initial 2-second-deferred IOBluetooth setup (TCC dialog timing) is preserved. `initTask` and `pollTask` are now separate so `start()` never launches the poll loop directly.
- `docs/rules-engine.md` is updated to document the multiplicative model.
- Build verified: `swift build` passes cleanly.

## Test plan

- [ ] No Bluetooth rules → confirm `[BluetoothSensor] no rules reference Bluetooth keys` log at startup
- [ ] Add a Bluetooth rule → confirm `[BluetoothSensor] rules reference Bluetooth keys — starting poll loop` log
- [ ] Remove all Bluetooth rules → confirm poll loop stops
- [ ] Same flow for WiFi `visible_networks`
- [ ] Rule negation: a negated rule should contribute confidence when the condition is *not* matched
- [ ] Multiplicative model: combined weight of two rules should be less than either individual weight (e.g. 0.8 × 0.7 = 0.56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
