### PR TITLE
Add SwiftUI settings window with live rule diagnostics and rule engine bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ xcuserdata/
 
 # Generated app bundles (produced by `make run`)
 *.app/
+
+# ControlPlane plugin bundles (built artefacts, not source)
+*.plugin

--- a/Package.swift
+++ b/Package.swift
@@ -345,6 +345,7 @@ let package = Package(
             path: "Sources/ControlPlaneApp",
             linkerSettings: [
                 .linkedFramework("AppKit"),
+                .linkedFramework("SwiftUI"),
                 .linkedFramework("CoreLocation"),
                 .linkedFramework("UserNotifications"),
                 .linkedFramework("ServiceManagement"),

--- a/Sources/ControlPlaneApp/ActionsListView.swift
+++ b/Sources/ControlPlaneApp/ActionsListView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Lists the actions attached to a profile, with controls to add / remove / toggle.
+struct ActionsListView: View {
+
+    let profile: Profile
+    @ObservedObject var store: ControlPlaneStore
+
+    @State private var selectedActionIDs = Set<UUID>()
+    @State private var showingCreateAction = false
+
+    private var actions: [ProfileAction] { store.actions(for: profile.id) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if actions.isEmpty {
+                emptyState
+            } else {
+                actionTable
+            }
+            Divider()
+            toolbar
+        }
+        .sheet(isPresented: $showingCreateAction) {
+            CreateActionView(profile: profile, store: store) {}
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "bolt.badge.clock")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text("No actions for this profile")
+                .foregroundStyle(.secondary)
+            Button("Add Action") { showingCreateAction = true }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Table
+
+    private var actionTable: some View {
+        Table(actions, selection: $selectedActionIDs) {
+            TableColumn("") { action in
+                Toggle("", isOn: Binding(
+                    get: { action.enabled },
+                    set: { enabled in Task { await store.setProfileActionEnabled(action, enabled: enabled) } }
+                ))
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+            }
+            .width(24)
+
+            TableColumn("Type") { action in
+                Text(store.actionType(for: action.actionPluginID)?.displayName ?? action.actionPluginID)
+                    .lineLimit(1)
+            }
+
+            TableColumn("Trigger") { action in
+                Text(action.trigger == .onActivate ? "On Activate" : "On Deactivate")
+                    .foregroundStyle(action.trigger == .onActivate ? .green : .orange)
+            }
+            .width(110)
+
+            TableColumn("Config") { action in
+                Text(configSummary(action))
+                    .foregroundStyle(.secondary)
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1)
+            }
+        }
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            Button("Delete", role: .destructive) {
+                let toDelete = actions.filter { ids.contains($0.id) }
+                Task {
+                    for a in toDelete { await store.deleteProfileAction(a) }
+                    selectedActionIDs.removeAll()
+                }
+            }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 0) {
+            Button(action: { showingCreateAction = true }) {
+                Image(systemName: "plus").frame(width: 28, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .help("Add action")
+
+            Button(action: {
+                let toDelete = actions.filter { selectedActionIDs.contains($0.id) }
+                Task {
+                    for a in toDelete { await store.deleteProfileAction(a) }
+                    selectedActionIDs.removeAll()
+                }
+            }) {
+                Image(systemName: "minus").frame(width: 28, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .disabled(selectedActionIDs.isEmpty)
+            .help("Remove selected actions")
+
+            Spacer()
+
+            Text("\(actions.count) action\(actions.count == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.trailing, 8)
+        }
+        .padding(.horizontal, 2)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Helpers
+
+    private func configSummary(_ action: ProfileAction) -> String {
+        action.config
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: "  ")
+    }
+}

--- a/Sources/ControlPlaneApp/AppDelegate.swift
+++ b/Sources/ControlPlaneApp/AppDelegate.swift
@@ -3,12 +3,16 @@ import Combine
 import UserNotifications
 import ControlPlaneSDK
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem?
     private let backend = Backend()
     private var store: ControlPlaneStore!
     private var cancellables = Set<AnyCancellable>()
+
+    /// Kept so we can refresh its submenu without rebuilding the whole menu.
+    private var runActionsMenuItem: NSMenuItem?
 
     // MARK: - Lifecycle
 
@@ -22,10 +26,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // AppDelegate observes store.$activeProfiles via Combine instead of
         // registering its own callback directly.
         store = ControlPlaneStore(backend: backend)
+
         store.$activeProfiles
             .receive(on: DispatchQueue.main)
             .sink { [weak self] active in self?.rebuildProfileSection(active) }
             .store(in: &cancellables)
+
+        // Rebuild the Run Actions submenu whenever actions, profiles, or action types change.
+        store.$profileActions
+            .combineLatest(store.$profiles, store.$actionTypes)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildRunActionsMenu() }
+            .store(in: &cancellables)
+
         Task { await store.setup() }
 
         CpctlInstaller.installIfNeeded()
@@ -35,32 +48,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupNotifications() {
         let center = UNUserNotificationCenter.current()
-
-        // Delegate must be set before any notification is delivered.
         center.delegate = self
-
-        // Discard any notifications that were queued by a previous instance
-        // but not yet delivered (e.g. time-triggered notifications left over
-        // from a crash or rapid restart during development).
         center.removeAllPendingNotificationRequests()
-
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error { log("Notification authorization error: \(error)") }
             log("Notification permission: \(granted ? "granted" : "denied")")
-            if granted {
-                Notifier.startup()
-            }
+            if granted { Notifier.startup() }
         }
     }
 
     // MARK: - Status Item
 
     private func setupStatusItem() {
-        // Variable length so the button can grow to show the active profile name.
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         guard let button = statusItem?.button else { return }
 
-        // Airplane SF Symbol — template image adapts to dark/light mode automatically.
         let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
         if let image = NSImage(systemSymbolName: "airplane", accessibilityDescription: "ControlPlane")?
                            .withSymbolConfiguration(config) {
@@ -72,23 +74,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem?.menu = buildMenu(active: [])
     }
 
-    /// Update the button title to show the active profile name(s) next to the icon.
     private func updateStatusTitle(_ active: [ActiveProfile]) {
         guard let button = statusItem?.button else { return }
-        if active.isEmpty {
-            button.title = ""
-        } else {
-            button.title = " " + active.map(\.profile.name).joined(separator: ", ")
-        }
+        button.title = active.isEmpty ? "" : " " + active.map(\.profile.name).joined(separator: ", ")
     }
 
-    @objc private func openPreferences() {
-        // NSMenuItem actions are always dispatched on the main thread;
-        // wrap in a MainActor Task to satisfy the static isolation check.
-        Task { @MainActor in
-            PreferencesWindowController.show(store: store)
-        }
-    }
+    // MARK: - Menu construction
 
     private func buildMenu(active: [ActiveProfile]) -> NSMenu {
         let menu = NSMenu()
@@ -105,8 +96,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                        keyEquivalent: ",")
         )
 
-        // tag 2 marks the separator just before the profile items so
-        // rebuildProfileSection can find the right insertion point.
+        // Run Actions flyout — submenu is populated by rebuildRunActionsMenu().
+        let runItem = NSMenuItem(title: "Run Action", action: nil, keyEquivalent: "")
+        runItem.submenu = NSMenu(title: "Run Action")
+        runActionsMenuItem = runItem
+        menu.addItem(runItem)
+
+        // tag 2 — anchor for rebuildProfileSection insertion.
         let profileSeparator = NSMenuItem.separator()
         profileSeparator.tag = 2
         menu.addItem(profileSeparator)
@@ -135,6 +131,79 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return menu
     }
 
+    // MARK: - Run Actions submenu
+
+    private func rebuildRunActionsMenu() {
+        guard let submenu = runActionsMenuItem?.submenu else { return }
+        submenu.removeAllItems()
+
+        // Sort by profile name, then by creation date within a profile.
+        let actions = store.profileActions.sorted { a, b in
+            let nameA = store.profiles.first { $0.id == a.profileID }?.name ?? ""
+            let nameB = store.profiles.first { $0.id == b.profileID }?.name ?? ""
+            return nameA == nameB ? a.createdAt < b.createdAt : nameA < nameB
+        }
+
+        if actions.isEmpty {
+            let empty = NSMenuItem(title: "No actions configured", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            submenu.addItem(empty)
+            return
+        }
+
+        // Group by profile with a section header for each.
+        var lastProfileID: UUID? = nil
+        for action in actions {
+            let profileName = store.profiles.first { $0.id == action.profileID }?.name ?? "Unknown Profile"
+            let typeName    = store.actionType(for: action.actionPluginID)?.displayName ?? action.actionPluginID
+            let trigger     = action.trigger == ActionTrigger.onActivate ? "activate" : "deactivate"
+
+            if action.profileID != lastProfileID {
+                if lastProfileID != nil { submenu.addItem(.separator()) }
+                let header = NSMenuItem(title: profileName, action: nil, keyEquivalent: "")
+                header.isEnabled = false
+                submenu.addItem(header)
+                lastProfileID = action.profileID
+            }
+
+            let title = "  \(typeName) (\(trigger))"
+            let item = NSMenuItem(title: title, action: #selector(runActionItem(_:)), keyEquivalent: "")
+            item.representedObject = action
+            item.target = self
+            if !action.enabled {
+                item.isEnabled = false
+                item.title = title + " [disabled]"
+            }
+            submenu.addItem(item)
+        }
+    }
+
+    @objc private func runActionItem(_ sender: NSMenuItem) {
+        guard let action = sender.representedObject as? ProfileAction else { return }
+        // Access @MainActor-isolated store on the main actor, then hop to a plain
+        // Task for the async plugin execution.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let profile = self.store.profiles.first(where: { $0.id == action.profileID }) else {
+                log("Run Action: profile \(action.profileID) not found")
+                return
+            }
+            guard let plugin = await self.backend.actionRegistry.plugin(for: action.actionPluginID) else {
+                log("Run Action: plugin '\(action.actionPluginID)' not loaded")
+                return
+            }
+            do {
+                log("Run Action: executing \(action.actionPluginID) [\(action.trigger.rawValue)] for \"\(profile.name)\"")
+                try await plugin.execute(trigger: action.trigger, profile: profile, config: action.config)
+                log("Run Action: done")
+            } catch {
+                log("Run Action failed: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Profile section
+
     private func rebuildProfileSection(_ active: [ActiveProfile]) {
         updateStatusTitle(active)
 
@@ -142,7 +211,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.items.filter { $0.tag == 1 }.forEach { menu.removeItem($0) }
 
-        // Find the separator tagged 2 (the one right before the profile items).
         guard let separatorIndex = menu.items.firstIndex(where: { $0.tag == 2 }) else { return }
         let insertAt = separatorIndex + 1
 
@@ -160,13 +228,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
+
+    // MARK: - Actions
+
+    @objc private func openPreferences() {
+        Task { @MainActor in
+            PreferencesWindowController.show(store: store)
+        }
+    }
 }
 
 // MARK: - UNUserNotificationCenterDelegate
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    /// Called when a notification is about to be presented while the app is running.
-    /// Returning .banner + .sound ensures the banner pops up even in the foreground.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,

--- a/Sources/ControlPlaneApp/AppDelegate.swift
+++ b/Sources/ControlPlaneApp/AppDelegate.swift
@@ -56,19 +56,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Status Item
 
     private func setupStatusItem() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        // Variable length so the button can grow to show the active profile name.
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         guard let button = statusItem?.button else { return }
 
-        // Use the "airplane" SF Symbol as a template image — it renders in monochrome,
-        // scales to any menu-bar size, and adapts to dark/light mode automatically.
-        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+        // Airplane SF Symbol — template image adapts to dark/light mode automatically.
+        let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
         if let image = NSImage(systemSymbolName: "airplane", accessibilityDescription: "ControlPlane")?
                            .withSymbolConfiguration(config) {
             button.image = image
+            button.imagePosition = .imageLeft
         }
 
         button.setAccessibilityLabel("ControlPlane")
         statusItem?.menu = buildMenu(active: [])
+    }
+
+    /// Update the button title to show the active profile name(s) next to the icon.
+    private func updateStatusTitle(_ active: [ActiveProfile]) {
+        guard let button = statusItem?.button else { return }
+        if active.isEmpty {
+            button.title = ""
+        } else {
+            button.title = " " + active.map(\.profile.name).joined(separator: ", ")
+        }
     }
 
     @objc private func openPreferences() {
@@ -125,6 +136,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func rebuildProfileSection(_ active: [ActiveProfile]) {
+        updateStatusTitle(active)
+
         guard let menu = statusItem?.menu else { return }
 
         menu.items.filter { $0.tag == 1 }.forEach { menu.removeItem($0) }

--- a/Sources/ControlPlaneApp/AppDelegate.swift
+++ b/Sources/ControlPlaneApp/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import UserNotifications
 import ControlPlaneSDK
 
@@ -6,6 +7,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem?
     private let backend = Backend()
+    private var store: ControlPlaneStore!
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Lifecycle
 
@@ -13,7 +16,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupNotifications()
         setupStatusItem()
         backend.start()
-        observeActiveProfiles()
+
+        // Create the observable store and register it as the active-profile observer.
+        // The store's setup() calls profileActivationManager.setOnChange, so
+        // AppDelegate observes store.$activeProfiles via Combine instead of
+        // registering its own callback directly.
+        store = ControlPlaneStore(backend: backend)
+        store.$activeProfiles
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] active in self?.rebuildProfileSection(active) }
+            .store(in: &cancellables)
+        Task { await store.setup() }
+
         CpctlInstaller.installIfNeeded()
     }
 
@@ -39,16 +53,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Active profile observation
-
-    private func observeActiveProfiles() {
-        Task {
-            await backend.profileActivationManager.setOnChange { [weak self] active in
-                DispatchQueue.main.async { self?.rebuildProfileSection(active) }
-            }
-        }
-    }
-
     // MARK: - Status Item
 
     private func setupStatusItem() {
@@ -67,6 +71,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem?.menu = buildMenu(active: [])
     }
 
+    @objc private func openPreferences() {
+        // NSMenuItem actions are always dispatched on the main thread;
+        // wrap in a MainActor Task to satisfy the static isolation check.
+        Task { @MainActor in
+            PreferencesWindowController.show(store: store)
+        }
+    }
+
     private func buildMenu(active: [ActiveProfile]) -> NSMenu {
         let menu = NSMenu()
 
@@ -75,6 +87,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(header)
 
         menu.addItem(.separator())
+
+        menu.addItem(
+            NSMenuItem(title: "Preferences…",
+                       action: #selector(openPreferences),
+                       keyEquivalent: ",")
+        )
+
+        // tag 2 marks the separator just before the profile items so
+        // rebuildProfileSection can find the right insertion point.
+        let profileSeparator = NSMenuItem.separator()
+        profileSeparator.tag = 2
+        menu.addItem(profileSeparator)
 
         if active.isEmpty {
             let item = NSMenuItem(title: "No active profile", action: nil, keyEquivalent: "")
@@ -105,7 +129,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.items.filter { $0.tag == 1 }.forEach { menu.removeItem($0) }
 
-        guard let separatorIndex = menu.items.firstIndex(where: { $0.isSeparatorItem }) else { return }
+        // Find the separator tagged 2 (the one right before the profile items).
+        guard let separatorIndex = menu.items.firstIndex(where: { $0.tag == 2 }) else { return }
         let insertAt = separatorIndex + 1
 
         if active.isEmpty {

--- a/Sources/ControlPlaneApp/Backend.swift
+++ b/Sources/ControlPlaneApp/Backend.swift
@@ -165,8 +165,13 @@ final class Backend {
     }
 
     /// Queries all rules and pushes each sensor's monitored key set to any
-    /// DynamicKeySensor that has rules referencing it.
-    /// Call this after any rule create, update, or delete.
+    /// DynamicKeySensor that has rules referencing it, then forces an immediate
+    /// rule evaluation with current sensor snapshots.
+    ///
+    /// Called after any rule create, update, or delete. The explicit
+    /// triggerSnapshotCallback() at the end ensures that rule changes take effect
+    /// immediately even when no dynamic sensor happens to fire on its own (e.g.
+    /// a MountedVolume or WiFi rule that was just edited).
     func refreshDynamicSensorKeys() async {
         do {
             let rules = try await ruleStore.list()
@@ -184,6 +189,10 @@ final class Backend {
         } catch {
             log("refreshDynamicSensorKeys error: \(error)")
         }
+        // Force an evaluation with current snapshots so that rule edits (negate
+        // toggle, weight change, enable/disable) take effect immediately regardless
+        // of whether any sensor happened to push a new snapshot on its own.
+        await sensorCoordinator.triggerSnapshotCallback()
     }
 
     private func registerSensor(_ sensor: any SensorPlugin) async {

--- a/Sources/ControlPlaneApp/ControlPlaneStore.swift
+++ b/Sources/ControlPlaneApp/ControlPlaneStore.swift
@@ -174,6 +174,32 @@ final class ControlPlaneStore: ObservableObject {
         }
     }
 
+    func updateRule(
+        _ rule: Rule,
+        name: String,
+        sensorID: String,
+        readingKey: String,
+        operatorID: String,
+        comparand: ObservationValue,
+        weight: Double,
+        negate: Bool,
+        enabled: Bool
+    ) async {
+        do {
+            let updated = try await backend.ruleStore.update(
+                id: rule.id, name: name, sensorID: sensorID,
+                readingKey: readingKey, operatorID: operatorID, comparand: comparand,
+                evaluatorID: rule.evaluatorID, weight: weight, negate: negate, enabled: enabled
+            )
+            if let idx = rules.firstIndex(where: { $0.id == rule.id }) {
+                rules[idx] = updated
+            }
+            await backend.refreshDynamicSensorKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func deleteRule(_ rule: Rule) async {
         do {
             try await backend.ruleStore.delete(rule.id)

--- a/Sources/ControlPlaneApp/ControlPlaneStore.swift
+++ b/Sources/ControlPlaneApp/ControlPlaneStore.swift
@@ -20,6 +20,10 @@ final class ControlPlaneStore: ObservableObject {
     @Published var activeProfiles: [ActiveProfile] = []
     @Published var errorMessage: String?
 
+    /// IDs of sensors that are DynamicKeySensor — their reading keys come from
+    /// rules rather than from the snapshot, so the UI must let the user type a key.
+    @Published var dynamicSensorIDs: Set<String> = []
+
     // MARK: - Internal
 
     let backend: Backend
@@ -63,6 +67,9 @@ final class ControlPlaneStore: ObservableObject {
 
         let evals = await backend.evaluatorRegistry.list()
         operators = evals.flatMap { $0.operators }
+
+        let dynIDs = await backend.sensorCoordinator.dynamicSensorIDs()
+        dynamicSensorIDs = Set(dynIDs)
 
         await refreshSnapshots()
         await refreshProfileActions()

--- a/Sources/ControlPlaneApp/ControlPlaneStore.swift
+++ b/Sources/ControlPlaneApp/ControlPlaneStore.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Combine
+import ControlPlaneSDK
+
+/// Observable data model that bridges the actor-based backend to SwiftUI.
+///
+/// All mutations happen on the MainActor; async backend calls are dispatched
+/// from there and results are written back on the main thread.
+@MainActor
+final class ControlPlaneStore: ObservableObject {
+
+    // MARK: - Published state
+
+    @Published var profiles: [Profile] = []
+    @Published var rules: [Rule] = []
+    @Published var profileActions: [ProfileAction] = []
+    @Published var snapshots: [SensorSnapshot] = []
+    @Published var actionTypes: [ActionTypeInfo] = []
+    @Published var operators: [OperatorDescriptor] = []
+    @Published var activeProfiles: [ActiveProfile] = []
+    @Published var errorMessage: String?
+
+    // MARK: - Internal
+
+    let backend: Backend
+    private var snapshotRefreshTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(backend: Backend) {
+        self.backend = backend
+    }
+
+    // MARK: - Setup
+
+    /// Wire callbacks and load initial data. Call once after the backend has started.
+    func setup() async {
+        // Register for active-profile change notifications.
+        // This replaces any previous setOnChange handler (e.g. the one used
+        // by AppDelegate to rebuild the menu — AppDelegate now observes
+        // store.$activeProfiles via Combine instead).
+        await backend.profileActivationManager.setOnChange { [weak self] active in
+            Task { @MainActor [weak self] in
+                self?.activeProfiles = active
+            }
+        }
+
+        await refresh()
+        startSnapshotRefresh()
+    }
+
+    // MARK: - Data refresh
+
+    /// Reload all data from the backend.
+    func refresh() async {
+        do { profiles = try await backend.profileStore.list() }
+        catch { errorMessage = error.localizedDescription }
+
+        do { rules = try await backend.ruleStore.list() }
+        catch { errorMessage = error.localizedDescription }
+
+        actionTypes = await backend.actionRegistry.list()
+
+        let evals = await backend.evaluatorRegistry.list()
+        operators = evals.flatMap { $0.operators }
+
+        await refreshSnapshots()
+        await refreshProfileActions()
+    }
+
+    func refreshSnapshots() async {
+        snapshots = await backend.sensorCoordinator.allSnapshots()
+    }
+
+    func refreshProfileActions() async {
+        do {
+            var all: [ProfileAction] = []
+            for p in profiles {
+                let actions = try await backend.profileActionStore.list(forProfile: p.id)
+                all += actions
+            }
+            profileActions = all
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Poll sensor snapshots every 2 s so the Sensors tab stays live.
+    private func startSnapshotRefresh() {
+        snapshotRefreshTask?.cancel()
+        snapshotRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !Task.isCancelled else { return }
+                await self?.refreshSnapshots()
+            }
+        }
+    }
+
+    // MARK: - Profile CRUD
+
+    func createProfile(name: String, confidenceThreshold: Double = 1.0, exclusive: Bool = false) async {
+        do {
+            let p = try await backend.profileStore.create(
+                name: name, parentID: nil,
+                exclusive: exclusive,
+                confidenceThreshold: confidenceThreshold
+            )
+            profiles.append(p)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func updateProfile(
+        _ profile: Profile,
+        name: String,
+        confidenceThreshold: Double,
+        exclusive: Bool
+    ) async {
+        do {
+            let updated = try await backend.profileStore.update(
+                id: profile.id, name: name, parentID: profile.parentID,
+                exclusive: exclusive, confidenceThreshold: confidenceThreshold
+            )
+            if let idx = profiles.firstIndex(where: { $0.id == profile.id }) {
+                profiles[idx] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteProfile(_ profile: Profile) async {
+        do {
+            try await backend.profileStore.delete(profile.id)
+            profiles.removeAll { $0.id == profile.id }
+            rules.removeAll { $0.profileID == profile.id }
+            profileActions.removeAll { $0.profileID == profile.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Rule CRUD
+
+    func createRule(
+        name: String,
+        profileID: UUID,
+        sensorID: String,
+        readingKey: String,
+        operatorID: String,
+        comparand: ObservationValue,
+        weight: Double = 1.0,
+        negate: Bool = false
+    ) async {
+        do {
+            let r = try await backend.ruleStore.create(
+                name: name, profileID: profileID, sensorID: sensorID,
+                readingKey: readingKey, operatorID: operatorID, comparand: comparand,
+                weight: weight, negate: negate
+            )
+            rules.append(r)
+            await backend.refreshDynamicSensorKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteRule(_ rule: Rule) async {
+        do {
+            try await backend.ruleStore.delete(rule.id)
+            rules.removeAll { $0.id == rule.id }
+            await backend.refreshDynamicSensorKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func setRuleEnabled(_ rule: Rule, enabled: Bool) async {
+        do {
+            let updated = try await backend.ruleStore.update(
+                id: rule.id, name: rule.name, sensorID: rule.sensorID,
+                readingKey: rule.readingKey, operatorID: rule.operatorID,
+                comparand: rule.comparand, evaluatorID: rule.evaluatorID,
+                weight: rule.weight, negate: rule.negate, enabled: enabled
+            )
+            if let idx = rules.firstIndex(where: { $0.id == rule.id }) {
+                rules[idx] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - ProfileAction CRUD
+
+    func createProfileAction(
+        profileID: UUID,
+        actionPluginID: String,
+        trigger: ActionTrigger,
+        config: [String: String]
+    ) async {
+        do {
+            let a = try await backend.profileActionStore.create(
+                profileID: profileID, actionPluginID: actionPluginID,
+                trigger: trigger, config: config
+            )
+            profileActions.append(a)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteProfileAction(_ action: ProfileAction) async {
+        do {
+            try await backend.profileActionStore.delete(action.id)
+            profileActions.removeAll { $0.id == action.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func setProfileActionEnabled(_ action: ProfileAction, enabled: Bool) async {
+        do {
+            let updated = try await backend.profileActionStore.update(
+                id: action.id, actionPluginID: action.actionPluginID,
+                trigger: action.trigger, config: action.config, enabled: enabled
+            )
+            if let idx = profileActions.firstIndex(where: { $0.id == action.id }) {
+                profileActions[idx] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Derived helpers
+
+    func rules(for profileID: UUID) -> [Rule] {
+        rules.filter { $0.profileID == profileID }.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func actions(for profileID: UUID) -> [ProfileAction] {
+        profileActions.filter { $0.profileID == profileID }.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func isActive(_ profileID: UUID) -> Bool {
+        activeProfiles.contains { $0.profile.id == profileID }
+    }
+
+    func confidence(for profileID: UUID) -> Double? {
+        activeProfiles.first { $0.profile.id == profileID }?.confidence
+    }
+
+    func actionType(for id: String) -> ActionTypeInfo? {
+        actionTypes.first { $0.id == id }
+    }
+
+    func snapshot(for sensorID: String) -> SensorSnapshot? {
+        snapshots.first { $0.sensorID == sensorID }
+    }
+
+    /// The `type` string for an ObservationValue ("string", "boolean", "number", "strings").
+    func valueType(_ value: ObservationValue) -> String {
+        switch value {
+        case .string:  return "string"
+        case .boolean: return "boolean"
+        case .number:  return "number"
+        case .strings: return "strings"
+        }
+    }
+
+    /// Operators that accept a given value type.
+    func operators(for valueType: String) -> [OperatorDescriptor] {
+        operators.filter { $0.applicableTypes.contains(valueType) }
+    }
+}

--- a/Sources/ControlPlaneApp/ControlPlaneStore.swift
+++ b/Sources/ControlPlaneApp/ControlPlaneStore.swift
@@ -20,6 +20,14 @@ final class ControlPlaneStore: ObservableObject {
     @Published var activeProfiles: [ActiveProfile] = []
     @Published var errorMessage: String?
 
+    /// Most recent per-rule match state from the last rule engine evaluation.
+    /// Keyed by rule UUID. Only contains entries for enabled rules.
+    @Published var ruleMatches: [UUID: Bool] = [:]
+
+    /// Current confidence score for every profile, including those below their threshold.
+    /// Profiles with no matching rules have a score of 0.0.
+    @Published var profileConfidences: [UUID: Double] = [:]
+
     /// IDs of sensors that are DynamicKeySensor — their reading keys come from
     /// rules rather than from the snapshot, so the UI must let the user type a key.
     @Published var dynamicSensorIDs: Set<String> = []
@@ -46,6 +54,15 @@ final class ControlPlaneStore: ObservableObject {
         await backend.profileActivationManager.setOnChange { [weak self] active in
             Task { @MainActor [weak self] in
                 self?.activeProfiles = active
+            }
+        }
+
+        // Register for rule-engine evaluation results so the UI can show live
+        // per-rule match state and per-profile confidence scores in real time.
+        await backend.ruleEngine.setOnEvaluated { [weak self] matches, confidences in
+            Task { @MainActor [weak self] in
+                self?.ruleMatches = matches
+                self?.profileConfidences = confidences
             }
         }
 
@@ -284,6 +301,12 @@ final class ControlPlaneStore: ObservableObject {
 
     func confidence(for profileID: UUID) -> Double? {
         activeProfiles.first { $0.profile.id == profileID }?.confidence
+    }
+
+    /// Current combined confidence for a profile, even if it is below its activation
+    /// threshold. Returns 0.0 before the first rule evaluation or when no rules match.
+    func currentConfidence(for profileID: UUID) -> Double {
+        profileConfidences[profileID] ?? 0.0
     }
 
     func actionType(for id: String) -> ActionTypeInfo? {

--- a/Sources/ControlPlaneApp/CreateActionView.swift
+++ b/Sources/ControlPlaneApp/CreateActionView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 import ControlPlaneSDK
 
 /// Sheet for creating a new action on a profile.
 ///
 /// Picks action type → trigger → fills in config fields from configDescriptors.
+/// Config keys that represent file-system paths get a Browse button in addition
+/// to the text field; the panel is scoped appropriately for each action type.
 struct CreateActionView: View {
 
     let profile: Profile
@@ -22,12 +26,10 @@ struct CreateActionView: View {
 
     private var canSave: Bool {
         guard let t = selectedType else { return false }
-        // All required fields must be filled
         return t.configDescriptors
             .filter { $0.required }
             .allSatisfy { desc in
-                let v = configValues[desc.key] ?? ""
-                return !v.trimmingCharacters(in: .whitespaces).isEmpty
+                !(configValues[desc.key] ?? "").trimmingCharacters(in: .whitespaces).isEmpty == false
             }
     }
 
@@ -37,7 +39,6 @@ struct CreateActionView: View {
                 .font(.headline)
 
             Form {
-                // --- Action type ---
                 Section {
                     Picker("Action Type", selection: $actionTypeID) {
                         Text("Choose…").tag("")
@@ -47,7 +48,6 @@ struct CreateActionView: View {
                     }
                     .onChange(of: actionTypeID) { _ in
                         configValues = [:]
-                        // Pre-fill defaults
                         if let t = selectedType {
                             for desc in t.configDescriptors {
                                 if let def = desc.defaultValue {
@@ -56,30 +56,22 @@ struct CreateActionView: View {
                             }
                         }
                     }
-                } header: {
-                    Text("Type")
-                }
+                } header: { Text("Type") }
 
-                // --- Trigger ---
                 Section {
                     Picker("Trigger", selection: $trigger) {
                         Text("On Activate").tag(ActionTrigger.onActivate)
                         Text("On Deactivate").tag(ActionTrigger.onDeactivate)
                     }
                     .pickerStyle(.segmented)
-                } header: {
-                    Text("Trigger")
-                }
+                } header: { Text("Trigger") }
 
-                // --- Config fields ---
                 if let t = selectedType, !t.configDescriptors.isEmpty {
                     Section {
                         ForEach(t.configDescriptors, id: \.key) { desc in
                             configField(desc)
                         }
-                    } header: {
-                        Text("Configuration")
-                    }
+                    } header: { Text("Configuration") }
                 }
             }
             .formStyle(.grouped)
@@ -94,9 +86,10 @@ struct CreateActionView: View {
             }
         }
         .padding(20)
-        .frame(width: 440, height: 420)
+        .frame(width: 480, height: 440)
         .onAppear {
-            if actionTypeID.isEmpty, let first = store.actionTypes.sorted(by: { $0.displayName < $1.displayName }).first {
+            if actionTypeID.isEmpty,
+               let first = store.actionTypes.sorted(by: { $0.displayName < $1.displayName }).first {
                 actionTypeID = first.id
                 for desc in first.configDescriptors {
                     if let def = desc.defaultValue { configValues[desc.key] = def }
@@ -111,14 +104,34 @@ struct CreateActionView: View {
     private func configField(_ desc: ActionConfigDescriptor) -> some View {
         LabeledContent(desc.label) {
             VStack(alignment: .leading, spacing: 4) {
-                TextField(
-                    desc.defaultValue ?? (desc.required ? "Required" : "Optional"),
-                    text: Binding(
-                        get: { configValues[desc.key] ?? "" },
-                        set: { configValues[desc.key] = $0 }
+                if let panelConfig = pathPanelConfig(for: desc.key) {
+                    // Path field: text box + Browse button side by side
+                    HStack(spacing: 6) {
+                        TextField(
+                            desc.defaultValue ?? "/path/to/file",
+                            text: Binding(
+                                get: { configValues[desc.key] ?? "" },
+                                set: { configValues[desc.key] = $0 }
+                            )
+                        )
+                        .textFieldStyle(.roundedBorder)
+
+                        Button("Browse…") {
+                            browse(config: panelConfig, key: desc.key)
+                        }
+                        .controlSize(.small)
+                    }
+                } else {
+                    TextField(
+                        desc.defaultValue ?? (desc.required ? "Required" : "Optional"),
+                        text: Binding(
+                            get: { configValues[desc.key] ?? "" },
+                            set: { configValues[desc.key] = $0 }
+                        )
                     )
-                )
-                .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(.roundedBorder)
+                }
+
                 if !desc.description.isEmpty {
                     Text(desc.description)
                         .font(.caption)
@@ -128,10 +141,92 @@ struct CreateActionView: View {
         }
     }
 
+    // MARK: - Path panel configuration
+
+    /// Per-action, per-key panel settings.  Returns nil for non-path fields.
+    private func pathPanelConfig(for key: String) -> PathPanelConfig? {
+        switch actionTypeID {
+        case "com.controlplane.action.open":
+            if key == "path" {
+                return PathPanelConfig(
+                    title: "Choose a file or application to open",
+                    canChooseFiles: true,
+                    canChooseDirectories: true,
+                    allowedTypes: nil          // any file or .app bundle
+                )
+            }
+
+        case "com.controlplane.action.openandhide":
+            if key == "path" {
+                return PathPanelConfig(
+                    title: "Choose an application to open and hide",
+                    canChooseFiles: false,
+                    canChooseDirectories: true,
+                    allowedTypes: [.applicationBundle]
+                )
+            }
+
+        case "com.controlplane.action.shellscript":
+            if key == "scriptPath" {
+                return PathPanelConfig(
+                    title: "Choose a shell script",
+                    canChooseFiles: true,
+                    canChooseDirectories: false,
+                    allowedTypes: [.shellScript, .unixExecutable, .plainText]
+                )
+            }
+
+        case "com.controlplane.action.desktopbackground":
+            if key == "imagePath" {
+                return PathPanelConfig(
+                    title: "Choose a background image",
+                    canChooseFiles: true,
+                    canChooseDirectories: false,
+                    allowedTypes: [.image]
+                )
+            }
+
+        case "com.controlplane.action.unmountvolume":
+            if key == "volumePath" {
+                return PathPanelConfig(
+                    title: "Choose a volume to unmount",
+                    canChooseFiles: false,
+                    canChooseDirectories: true,
+                    allowedTypes: nil,
+                    directoryURL: URL(fileURLWithPath: "/Volumes")
+                )
+            }
+
+        default:
+            break
+        }
+        return nil
+    }
+
+    private func browse(config: PathPanelConfig, key: String) {
+        let panel = NSOpenPanel()
+        panel.title = config.title
+        panel.canChooseFiles = config.canChooseFiles
+        panel.canChooseDirectories = config.canChooseDirectories
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        if let types = config.allowedTypes {
+            panel.allowedContentTypes = types
+        }
+        if let dir = config.directoryURL {
+            panel.directoryURL = dir
+        }
+        if panel.runModal() == .OK, let url = panel.url {
+            configValues[key] = url.path
+        }
+    }
+
     // MARK: - Save
 
     private func save() {
-        let cleanedConfig = configValues.filter { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }
+        let cleanedConfig = configValues.filter {
+            !$0.value.trimmingCharacters(in: .whitespaces).isEmpty
+        }
         Task {
             await store.createProfileAction(
                 profileID: profile.id,
@@ -143,4 +238,14 @@ struct CreateActionView: View {
             dismiss()
         }
     }
+}
+
+// MARK: - Path panel configuration struct
+
+private struct PathPanelConfig {
+    let title: String
+    let canChooseFiles: Bool
+    let canChooseDirectories: Bool
+    let allowedTypes: [UTType]?
+    var directoryURL: URL? = nil
 }

--- a/Sources/ControlPlaneApp/CreateActionView.swift
+++ b/Sources/ControlPlaneApp/CreateActionView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Sheet for creating a new action on a profile.
+///
+/// Picks action type → trigger → fills in config fields from configDescriptors.
+struct CreateActionView: View {
+
+    let profile: Profile
+    @ObservedObject var store: ControlPlaneStore
+    let onSave: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var actionTypeID = ""
+    @State private var trigger: ActionTrigger = .onActivate
+    @State private var configValues: [String: String] = [:]
+
+    private var selectedType: ActionTypeInfo? {
+        store.actionTypes.first { $0.id == actionTypeID }
+    }
+
+    private var canSave: Bool {
+        guard let t = selectedType else { return false }
+        // All required fields must be filled
+        return t.configDescriptors
+            .filter { $0.required }
+            .allSatisfy { desc in
+                let v = configValues[desc.key] ?? ""
+                return !v.trimmingCharacters(in: .whitespaces).isEmpty
+            }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("New Action")
+                .font(.headline)
+
+            Form {
+                // --- Action type ---
+                Section {
+                    Picker("Action Type", selection: $actionTypeID) {
+                        Text("Choose…").tag("")
+                        ForEach(store.actionTypes.sorted(by: { $0.displayName < $1.displayName })) { t in
+                            Text(t.displayName).tag(t.id)
+                        }
+                    }
+                    .onChange(of: actionTypeID) { _ in
+                        configValues = [:]
+                        // Pre-fill defaults
+                        if let t = selectedType {
+                            for desc in t.configDescriptors {
+                                if let def = desc.defaultValue {
+                                    configValues[desc.key] = def
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Type")
+                }
+
+                // --- Trigger ---
+                Section {
+                    Picker("Trigger", selection: $trigger) {
+                        Text("On Activate").tag(ActionTrigger.onActivate)
+                        Text("On Deactivate").tag(ActionTrigger.onDeactivate)
+                    }
+                    .pickerStyle(.segmented)
+                } header: {
+                    Text("Trigger")
+                }
+
+                // --- Config fields ---
+                if let t = selectedType, !t.configDescriptors.isEmpty {
+                    Section {
+                        ForEach(t.configDescriptors, id: \.key) { desc in
+                            configField(desc)
+                        }
+                    } header: {
+                        Text("Configuration")
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add Action") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 440, height: 420)
+        .onAppear {
+            if actionTypeID.isEmpty, let first = store.actionTypes.sorted(by: { $0.displayName < $1.displayName }).first {
+                actionTypeID = first.id
+                for desc in first.configDescriptors {
+                    if let def = desc.defaultValue { configValues[desc.key] = def }
+                }
+            }
+        }
+    }
+
+    // MARK: - Config field
+
+    @ViewBuilder
+    private func configField(_ desc: ActionConfigDescriptor) -> some View {
+        LabeledContent(desc.label) {
+            VStack(alignment: .leading, spacing: 4) {
+                TextField(
+                    desc.defaultValue ?? (desc.required ? "Required" : "Optional"),
+                    text: Binding(
+                        get: { configValues[desc.key] ?? "" },
+                        set: { configValues[desc.key] = $0 }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                if !desc.description.isEmpty {
+                    Text(desc.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        let cleanedConfig = configValues.filter { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }
+        Task {
+            await store.createProfileAction(
+                profileID: profile.id,
+                actionPluginID: actionTypeID,
+                trigger: trigger,
+                config: cleanedConfig
+            )
+            onSave()
+            dismiss()
+        }
+    }
+}

--- a/Sources/ControlPlaneApp/CreateActionView.swift
+++ b/Sources/ControlPlaneApp/CreateActionView.swift
@@ -29,7 +29,8 @@ struct CreateActionView: View {
         return t.configDescriptors
             .filter { $0.required }
             .allSatisfy { desc in
-                !(configValues[desc.key] ?? "").trimmingCharacters(in: .whitespaces).isEmpty == false
+                let v = configValues[desc.key] ?? ""
+                return !v.trimmingCharacters(in: .whitespaces).isEmpty
             }
     }
 

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import AppKit
 import ControlPlaneSDK
 
-/// Sheet for creating a new rule on a profile.
+/// Sheet for creating or editing a rule on a profile.
 ///
-/// Sensor → reading key → operator → comparand → weight → name.
+/// Pass `existingRule` to open in edit mode; omit it (nil) for create mode.
 ///
 /// Dynamic sensors (FilePresence, RunningApplication, HostAvailability, USB)
 /// don't emit readings until rules reference them. For those sensors the
@@ -17,6 +17,8 @@ struct CreateRuleView: View {
 
     let profile: Profile
     @ObservedObject var store: ControlPlaneStore
+    /// When non-nil the sheet operates in edit mode, pre-populating all fields.
+    let existingRule: Rule?
     let onSave: () -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -28,6 +30,44 @@ struct CreateRuleView: View {
     @State private var comparandString = ""
     @State private var weight          = 1.0
     @State private var negate          = false
+    @State private var ruleEnabled     = true
+
+    private var isEditing: Bool { existingRule != nil }
+
+    init(
+        profile: Profile,
+        store: ControlPlaneStore,
+        existingRule: Rule? = nil,
+        onSave: @escaping () -> Void = {}
+    ) {
+        self.profile      = profile
+        self.store        = store
+        self.existingRule = existingRule
+        self.onSave       = onSave
+
+        // Pre-populate @State from the existing rule.
+        if let r = existingRule {
+            _ruleName        = State(initialValue: r.name)
+            _sensorID        = State(initialValue: r.sensorID)
+            _readingKey      = State(initialValue: r.readingKey)
+            _operatorID      = State(initialValue: r.operatorID)
+            _comparandString = State(initialValue: Self.comparandToString(r.comparand))
+            _weight          = State(initialValue: r.weight)
+            _negate          = State(initialValue: r.negate)
+            _ruleEnabled     = State(initialValue: r.enabled)
+        }
+    }
+
+    /// Convert an ObservationValue back to its editable string representation.
+    private static func comparandToString(_ value: ObservationValue) -> String {
+        switch value {
+        case .boolean(let b): return b ? "true" : "false"
+        case .number(let n):
+            return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
+        case .strings(let arr): return arr.joined(separator: ", ")
+        case .string(let s): return s
+        }
+    }
 
     // MARK: - Derived
 
@@ -84,7 +124,7 @@ struct CreateRuleView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("New Rule")
+            Text(isEditing ? "Edit Rule" : "New Rule")
                 .font(.headline)
 
             Form {
@@ -95,6 +135,11 @@ struct CreateRuleView: View {
                     weightSection
                 }
                 nameSection
+                if isEditing {
+                    Section {
+                        Toggle("Enabled", isOn: $ruleEnabled)
+                    } header: { Text("Status") }
+                }
             }
             .formStyle(.grouped)
 
@@ -104,14 +149,15 @@ struct CreateRuleView: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                Button("Add Rule") { save() }
+                Button(isEditing ? "Save Changes" : "Add Rule") { save() }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!canSave)
             }
         }
         .padding(20)
-        .frame(width: 500, height: 580)
-        .onAppear { seedInitialSensor() }
+        .frame(width: 500, height: isEditing ? 620 : 580)
+        // Only seed sensor when creating; editing starts fully pre-populated.
+        .onAppear { if !isEditing { seedInitialSensor() } }
     }
 
     // MARK: - Sections
@@ -421,16 +467,30 @@ struct CreateRuleView: View {
         guard let comparand = makeComparand() else { return }
 
         Task {
-            await store.createRule(
-                name: name,
-                profileID: profile.id,
-                sensorID: sensorID,
-                readingKey: trimmedKey,
-                operatorID: operatorID,
-                comparand: comparand,
-                weight: weight,
-                negate: negate
-            )
+            if let existing = existingRule {
+                await store.updateRule(
+                    existing,
+                    name: name,
+                    sensorID: sensorID,
+                    readingKey: trimmedKey,
+                    operatorID: operatorID,
+                    comparand: comparand,
+                    weight: weight,
+                    negate: negate,
+                    enabled: ruleEnabled
+                )
+            } else {
+                await store.createRule(
+                    name: name,
+                    profileID: profile.id,
+                    sensorID: sensorID,
+                    readingKey: trimmedKey,
+                    operatorID: operatorID,
+                    comparand: comparand,
+                    weight: weight,
+                    negate: negate
+                )
+            }
             onSave()
             dismiss()
         }

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -1,9 +1,14 @@
 import SwiftUI
+import AppKit
 import ControlPlaneSDK
 
 /// Sheet for creating a new rule on a profile.
 ///
 /// Sensor → reading key → operator → comparand → weight → name.
+///
+/// Dynamic sensors (FilePresence, RunningApplication, HostAvailability, USB)
+/// don't emit readings until rules reference them. For those sensors the
+/// reading key is entered as free text (with a Browse button for FilePresence).
 struct CreateRuleView: View {
 
     let profile: Profile
@@ -12,32 +17,53 @@ struct CreateRuleView: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    // Step-driven state
-    @State private var ruleName   = ""
-    @State private var sensorID   = ""
-    @State private var readingKey = ""
-    @State private var operatorID = ""
+    @State private var ruleName        = ""
+    @State private var sensorID        = ""
+    @State private var readingKey      = ""
+    @State private var operatorID      = ""
     @State private var comparandString = ""
-    @State private var weight     = 1.0
-    @State private var negate     = false
+    @State private var weight          = 1.0
+    @State private var negate          = false
 
-    // Derived
+    // MARK: - Derived
+
+    private var isDynamic: Bool {
+        store.dynamicSensorIDs.contains(sensorID)
+    }
+
+    private var isFilePresence: Bool {
+        sensorID == "com.controlplane.sensors.filepresence"
+    }
+
     private var selectedSnapshot: SensorSnapshot? {
         store.snapshot(for: sensorID)
     }
+
     private var selectedReading: SensorReading? {
-        selectedSnapshot?.readings.first { $0.key == readingKey }
+        guard !isDynamic else { return nil }
+        return selectedSnapshot?.readings.first { $0.key == readingKey }
     }
+
+    /// The ObservationValue type string for the current reading.
     private var valueType: String {
-        guard let r = selectedReading else { return "string" }
-        return store.valueType(r.value)
+        if let r = selectedReading { return store.valueType(r.value) }
+        // Dynamic sensors always emit booleans (file exists, app running, host reachable…)
+        if isDynamic { return "boolean" }
+        return "string"
     }
+
     private var availableOperators: [OperatorDescriptor] {
         store.operators(for: valueType)
     }
+
     private var canSave: Bool {
-        !sensorID.isEmpty && !readingKey.isEmpty && !operatorID.isEmpty && !comparandString.isEmpty
+        !sensorID.isEmpty
+            && !readingKey.trimmingCharacters(in: .whitespaces).isEmpty
+            && !operatorID.isEmpty
+            && !comparandString.isEmpty
     }
+
+    // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -45,106 +71,17 @@ struct CreateRuleView: View {
                 .font(.headline)
 
             Form {
-                // --- Rule name ---
-                Section {
-                    TextField("Rule name (optional)", text: $ruleName)
-                        .textFieldStyle(.roundedBorder)
-                } header: {
-                    Text("Name")
+                sensorSection
+                readingKeySection
+                if !readingKey.trimmingCharacters(in: .whitespaces).isEmpty {
+                    conditionSection
+                    weightSection
                 }
-
-                // --- Sensor ---
-                Section {
-                    Picker("Sensor", selection: $sensorID) {
-                        Text("Choose…").tag("")
-                        ForEach(store.snapshots.sorted(by: { $0.displayName < $1.displayName }), id: \.sensorID) { snap in
-                            Text(snap.displayName).tag(snap.sensorID)
-                        }
-                    }
-                    .onChange(of: sensorID) { _ in
-                        readingKey = ""
-                        operatorID = ""
-                        comparandString = ""
-                    }
-                } header: {
-                    Text("Sensor")
-                }
-
-                // --- Reading key ---
-                if let snap = selectedSnapshot {
-                    Section {
-                        Picker("Reading", selection: $readingKey) {
-                            Text("Choose…").tag("")
-                            ForEach(snap.readings, id: \.key) { reading in
-                                HStack {
-                                    Text(reading.label)
-                                    Text("(\(reading.key))").foregroundStyle(.secondary).font(.caption)
-                                }
-                                .tag(reading.key)
-                            }
-                        }
-                        .onChange(of: readingKey) { _ in
-                            operatorID = ""
-                            comparandString = ""
-                            // Pre-fill comparand with current value
-                            if let r = selectedReading {
-                                comparandString = r.value.description
-                                // Auto-pick first compatible operator
-                                operatorID = store.operators(for: store.valueType(r.value)).first?.id ?? ""
-                            }
-                        }
-
-                        if let reading = selectedReading {
-                            LabeledContent("Current value") {
-                                Text(reading.value.description)
-                                    .foregroundStyle(.secondary)
-                                    .font(.system(.body, design: .monospaced))
-                            }
-                        }
-                    } header: {
-                        Text("Reading")
-                    }
-                }
-
-                // --- Operator + comparand ---
-                if !readingKey.isEmpty {
-                    Section {
-                        Toggle("Negate (NOT)", isOn: $negate)
-
-                        if !availableOperators.isEmpty {
-                            Picker("Operator", selection: $operatorID) {
-                                Text("Choose…").tag("")
-                                ForEach(availableOperators) { op in
-                                    Text("\(op.label)  (\(op.id))").tag(op.id)
-                                }
-                            }
-                        }
-
-                        comparandField
-                    } header: {
-                        Text("Condition")
-                    }
-
-                    Section {
-                        LabeledContent("Weight") {
-                            HStack {
-                                Slider(value: $weight, in: 0.1...2.0, step: 0.1)
-                                Text(String(format: "%.1f", weight))
-                                    .monospacedDigit()
-                                    .frame(width: 36, alignment: .trailing)
-                            }
-                        }
-                    } header: {
-                        Text("Weight")
-                    }
-                }
+                nameSection
             }
             .formStyle(.grouped)
 
-            // Summary preview
-            if canSave {
-                rulePreview
-            }
+            if canSave { rulePreview }
 
             HStack {
                 Spacer()
@@ -156,13 +93,130 @@ struct CreateRuleView: View {
             }
         }
         .padding(20)
-        .frame(width: 480, height: 580)
-        .onAppear {
-            // Auto-select first sensor when opening
-            if sensorID.isEmpty, let first = store.snapshots.first {
-                sensorID = first.sensorID
+        .frame(width: 500, height: 580)
+        .onAppear { seedInitialSensor() }
+    }
+
+    // MARK: - Sections
+
+    private var sensorSection: some View {
+        Section {
+            Picker("Sensor", selection: $sensorID) {
+                Text("Choose…").tag("")
+                ForEach(store.snapshots.sorted(by: { $0.displayName < $1.displayName }), id: \.sensorID) { snap in
+                    HStack {
+                        Text(snap.displayName)
+                        if store.dynamicSensorIDs.contains(snap.sensorID) {
+                            Text("(dynamic)").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .tag(snap.sensorID)
+                }
+            }
+            .onChange(of: sensorID) { _ in resetBelowSensor() }
+        } header: { Text("Sensor") }
+    }
+
+    @ViewBuilder
+    private var readingKeySection: some View {
+        if !sensorID.isEmpty {
+            Section {
+                if isDynamic {
+                    dynamicKeyField
+                } else if let snap = selectedSnapshot {
+                    staticKeyPicker(snap)
+                }
+            } header: { Text("Reading") }
+        }
+    }
+
+    /// Free-text entry for dynamic sensors (the key IS the path / bundle ID / hostname).
+    private var dynamicKeyField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                TextField(dynamicKeyPlaceholder, text: $readingKey)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: readingKey) { _ in resetBelowKey() }
+
+                if isFilePresence {
+                    Button("Browse…") { browseForFile() }
+                        .controlSize(.small)
+                }
+            }
+            Text(dynamicKeyHint)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Picker from the snapshot's known readings (non-dynamic sensors).
+    private func staticKeyPicker(_ snap: SensorSnapshot) -> some View {
+        Group {
+            Picker("Reading", selection: $readingKey) {
+                Text("Choose…").tag("")
+                ForEach(snap.readings, id: \.key) { r in
+                    HStack {
+                        Text(r.label)
+                        Text("(\(r.key))").font(.caption).foregroundStyle(.secondary)
+                    }
+                    .tag(r.key)
+                }
+            }
+            .onChange(of: readingKey) { _ in
+                resetBelowKey()
+                if let r = selectedReading {
+                    comparandString = r.value.description
+                    operatorID = store.operators(for: store.valueType(r.value)).first?.id ?? ""
+                }
+            }
+
+            if let r = selectedReading {
+                LabeledContent("Current value") {
+                    Text(r.value.description)
+                        .foregroundStyle(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private var conditionSection: some View {
+        Section {
+            Toggle("Negate (NOT)", isOn: $negate)
+
+            if !availableOperators.isEmpty {
+                Picker("Operator", selection: $operatorID) {
+                    Text("Choose…").tag("")
+                    ForEach(availableOperators) { op in
+                        Text("\(op.label)  (\(op.id))").tag(op.id)
+                    }
+                }
+                .onAppear { seedOperator() }
+            }
+
+            comparandField
+        } header: { Text("Condition") }
+    }
+
+    private var weightSection: some View {
+        Section {
+            LabeledContent("Weight") {
+                HStack {
+                    Slider(value: $weight, in: 0.1...2.0, step: 0.1)
+                    Text(String(format: "%.1f", weight))
+                        .monospacedDigit()
+                        .frame(width: 36, alignment: .trailing)
+                }
+            }
+        } header: { Text("Weight") }
+    }
+
+    private var nameSection: some View {
+        Section {
+            TextField("Auto-generated if blank", text: $ruleName)
+                .textFieldStyle(.roundedBorder)
+        } header: { Text("Name (optional)") }
     }
 
     // MARK: - Comparand field
@@ -172,13 +226,11 @@ struct CreateRuleView: View {
         switch valueType {
         case "boolean":
             Picker("Value", selection: $comparandString) {
-                Text("true").tag("true")
-                Text("false").tag("false")
+                Text("true  (exists / running / reachable)").tag("true")
+                Text("false (absent / stopped / unreachable)").tag("false")
             }
-            .pickerStyle(.segmented)
-            .onAppear {
-                if comparandString.isEmpty { comparandString = "true" }
-            }
+            .pickerStyle(.radioGroup)
+            .onAppear { if comparandString.isEmpty { comparandString = "true" } }
 
         case "number":
             LabeledContent("Value") {
@@ -195,25 +247,106 @@ struct CreateRuleView: View {
         }
     }
 
-    // MARK: - Preview
+    // MARK: - Rule preview
 
     private var rulePreview: some View {
         GroupBox("Preview") {
-            let negText  = negate ? "NOT " : ""
-            let opLabel  = store.operators.first { $0.id == operatorID }?.label ?? operatorID
+            let neg       = negate ? "NOT " : ""
+            let opLabel   = store.operators.first { $0.id == operatorID }?.label ?? operatorID
             let sensorName = store.snapshot(for: sensorID)?.displayName ?? sensorID
-            Text("\(negText)\(sensorName) › \(readingKey) \(opLabel) \"\(comparandString)\"  (weight \(String(format: "%.1f", weight)))")
-                .font(.system(.body, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(
+                "\(neg)\(sensorName) › \(readingKey.isEmpty ? "…" : readingKey)" +
+                " \(opLabel) \"\(comparandString)\"" +
+                "  (weight \(String(format: "%.1f", weight)))"
+            )
+            .font(.system(.body, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Dynamic sensor helpers
+
+    private var dynamicKeyPlaceholder: String {
+        switch sensorID {
+        case "com.controlplane.sensors.filepresence":
+            return "/path/to/file"
+        case "com.controlplane.sensors.runningapplication":
+            return "com.apple.safari"
+        case "com.controlplane.sensors.hostavailability":
+            return "server.local"
+        case "com.controlplane.sensors.usb":
+            return "vendorID:productID  e.g. 05ac:12a8"
+        default:
+            return "key"
+        }
+    }
+
+    private var dynamicKeyHint: String {
+        switch sensorID {
+        case "com.controlplane.sensors.filepresence":
+            return "Absolute path to the file or directory to watch."
+        case "com.controlplane.sensors.runningapplication":
+            return "Bundle identifier of the application (e.g. com.apple.safari)."
+        case "com.controlplane.sensors.hostavailability":
+            return "Hostname or IP address to ping."
+        case "com.controlplane.sensors.usb":
+            return "USB vendor and product ID in hex, colon-separated."
+        default:
+            return "Reading key for this sensor."
+        }
+    }
+
+    // MARK: - Browse for file
+
+    private func browseForFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a file or folder to watch"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+
+        if panel.runModal() == .OK, let url = panel.url {
+            readingKey = url.path
+            resetBelowKey()
+            // FilePresenceSensor always emits boolean
+            comparandString = "true"
+            seedOperator()
+        }
+    }
+
+    // MARK: - State helpers
+
+    private func resetBelowSensor() {
+        readingKey = ""
+        operatorID = ""
+        comparandString = ""
+    }
+
+    private func resetBelowKey() {
+        operatorID = ""
+        comparandString = ""
+    }
+
+    private func seedOperator() {
+        if operatorID.isEmpty {
+            operatorID = availableOperators.first?.id ?? ""
+        }
+    }
+
+    private func seedInitialSensor() {
+        if sensorID.isEmpty, let first = store.snapshots.first {
+            sensorID = first.sensorID
         }
     }
 
     // MARK: - Save
 
     private func save() {
+        let trimmedKey = readingKey.trimmingCharacters(in: .whitespaces)
         let name = ruleName.trimmingCharacters(in: .whitespaces).isEmpty
-            ? autoName()
+            ? autoName(key: trimmedKey)
             : ruleName.trimmingCharacters(in: .whitespaces)
 
         guard let comparand = makeComparand() else { return }
@@ -223,7 +356,7 @@ struct CreateRuleView: View {
                 name: name,
                 profileID: profile.id,
                 sensorID: sensorID,
-                readingKey: readingKey,
+                readingKey: trimmedKey,
                 operatorID: operatorID,
                 comparand: comparand,
                 weight: weight,
@@ -234,10 +367,11 @@ struct CreateRuleView: View {
         }
     }
 
-    private func autoName() -> String {
+    private func autoName(key: String) -> String {
         let sensorName = store.snapshot(for: sensorID)?.displayName ?? sensorID
-        let opLabel = store.operators.first { $0.id == operatorID }?.label ?? operatorID
-        return "\(sensorName) \(readingKey) \(opLabel) \(comparandString)"
+        let opLabel    = store.operators.first { $0.id == operatorID }?.label ?? operatorID
+        let keyShort   = key.count > 40 ? "…" + key.suffix(37) : key
+        return "\(sensorName) › \(keyShort) \(opLabel) \(comparandString)"
     }
 
     private func makeComparand() -> ObservationValue? {
@@ -248,10 +382,12 @@ struct CreateRuleView: View {
             guard let d = Double(comparandString) else { return nil }
             return .number(d)
         case "strings":
-            return .strings(comparandString
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .filter { !$0.isEmpty })
+            return .strings(
+                comparandString
+                    .split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+            )
         default:
             return .string(comparandString)
         }

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Sheet for creating a new rule on a profile.
+///
+/// Sensor → reading key → operator → comparand → weight → name.
+struct CreateRuleView: View {
+
+    let profile: Profile
+    @ObservedObject var store: ControlPlaneStore
+    let onSave: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    // Step-driven state
+    @State private var ruleName   = ""
+    @State private var sensorID   = ""
+    @State private var readingKey = ""
+    @State private var operatorID = ""
+    @State private var comparandString = ""
+    @State private var weight     = 1.0
+    @State private var negate     = false
+
+    // Derived
+    private var selectedSnapshot: SensorSnapshot? {
+        store.snapshot(for: sensorID)
+    }
+    private var selectedReading: SensorReading? {
+        selectedSnapshot?.readings.first { $0.key == readingKey }
+    }
+    private var valueType: String {
+        guard let r = selectedReading else { return "string" }
+        return store.valueType(r.value)
+    }
+    private var availableOperators: [OperatorDescriptor] {
+        store.operators(for: valueType)
+    }
+    private var canSave: Bool {
+        !sensorID.isEmpty && !readingKey.isEmpty && !operatorID.isEmpty && !comparandString.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("New Rule")
+                .font(.headline)
+
+            Form {
+                // --- Rule name ---
+                Section {
+                    TextField("Rule name (optional)", text: $ruleName)
+                        .textFieldStyle(.roundedBorder)
+                } header: {
+                    Text("Name")
+                }
+
+                // --- Sensor ---
+                Section {
+                    Picker("Sensor", selection: $sensorID) {
+                        Text("Choose…").tag("")
+                        ForEach(store.snapshots.sorted(by: { $0.displayName < $1.displayName }), id: \.sensorID) { snap in
+                            Text(snap.displayName).tag(snap.sensorID)
+                        }
+                    }
+                    .onChange(of: sensorID) { _ in
+                        readingKey = ""
+                        operatorID = ""
+                        comparandString = ""
+                    }
+                } header: {
+                    Text("Sensor")
+                }
+
+                // --- Reading key ---
+                if let snap = selectedSnapshot {
+                    Section {
+                        Picker("Reading", selection: $readingKey) {
+                            Text("Choose…").tag("")
+                            ForEach(snap.readings, id: \.key) { reading in
+                                HStack {
+                                    Text(reading.label)
+                                    Text("(\(reading.key))").foregroundStyle(.secondary).font(.caption)
+                                }
+                                .tag(reading.key)
+                            }
+                        }
+                        .onChange(of: readingKey) { _ in
+                            operatorID = ""
+                            comparandString = ""
+                            // Pre-fill comparand with current value
+                            if let r = selectedReading {
+                                comparandString = r.value.description
+                                // Auto-pick first compatible operator
+                                operatorID = store.operators(for: store.valueType(r.value)).first?.id ?? ""
+                            }
+                        }
+
+                        if let reading = selectedReading {
+                            LabeledContent("Current value") {
+                                Text(reading.value.description)
+                                    .foregroundStyle(.secondary)
+                                    .font(.system(.body, design: .monospaced))
+                            }
+                        }
+                    } header: {
+                        Text("Reading")
+                    }
+                }
+
+                // --- Operator + comparand ---
+                if !readingKey.isEmpty {
+                    Section {
+                        Toggle("Negate (NOT)", isOn: $negate)
+
+                        if !availableOperators.isEmpty {
+                            Picker("Operator", selection: $operatorID) {
+                                Text("Choose…").tag("")
+                                ForEach(availableOperators) { op in
+                                    Text("\(op.label)  (\(op.id))").tag(op.id)
+                                }
+                            }
+                        }
+
+                        comparandField
+                    } header: {
+                        Text("Condition")
+                    }
+
+                    Section {
+                        LabeledContent("Weight") {
+                            HStack {
+                                Slider(value: $weight, in: 0.1...2.0, step: 0.1)
+                                Text(String(format: "%.1f", weight))
+                                    .monospacedDigit()
+                                    .frame(width: 36, alignment: .trailing)
+                            }
+                        }
+                    } header: {
+                        Text("Weight")
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            // Summary preview
+            if canSave {
+                rulePreview
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add Rule") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 480, height: 580)
+        .onAppear {
+            // Auto-select first sensor when opening
+            if sensorID.isEmpty, let first = store.snapshots.first {
+                sensorID = first.sensorID
+            }
+        }
+    }
+
+    // MARK: - Comparand field
+
+    @ViewBuilder
+    private var comparandField: some View {
+        switch valueType {
+        case "boolean":
+            Picker("Value", selection: $comparandString) {
+                Text("true").tag("true")
+                Text("false").tag("false")
+            }
+            .pickerStyle(.segmented)
+            .onAppear {
+                if comparandString.isEmpty { comparandString = "true" }
+            }
+
+        case "number":
+            LabeledContent("Value") {
+                TextField("e.g. 42", text: $comparandString)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 120)
+            }
+
+        default: // string, strings
+            LabeledContent("Value") {
+                TextField("e.g. MyWifi", text: $comparandString)
+                    .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+
+    // MARK: - Preview
+
+    private var rulePreview: some View {
+        GroupBox("Preview") {
+            let negText  = negate ? "NOT " : ""
+            let opLabel  = store.operators.first { $0.id == operatorID }?.label ?? operatorID
+            let sensorName = store.snapshot(for: sensorID)?.displayName ?? sensorID
+            Text("\(negText)\(sensorName) › \(readingKey) \(opLabel) \"\(comparandString)\"  (weight \(String(format: "%.1f", weight)))")
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        let name = ruleName.trimmingCharacters(in: .whitespaces).isEmpty
+            ? autoName()
+            : ruleName.trimmingCharacters(in: .whitespaces)
+
+        guard let comparand = makeComparand() else { return }
+
+        Task {
+            await store.createRule(
+                name: name,
+                profileID: profile.id,
+                sensorID: sensorID,
+                readingKey: readingKey,
+                operatorID: operatorID,
+                comparand: comparand,
+                weight: weight,
+                negate: negate
+            )
+            onSave()
+            dismiss()
+        }
+    }
+
+    private func autoName() -> String {
+        let sensorName = store.snapshot(for: sensorID)?.displayName ?? sensorID
+        let opLabel = store.operators.first { $0.id == operatorID }?.label ?? operatorID
+        return "\(sensorName) \(readingKey) \(opLabel) \(comparandString)"
+    }
+
+    private func makeComparand() -> ObservationValue? {
+        switch valueType {
+        case "boolean":
+            return .boolean(comparandString == "true")
+        case "number":
+            guard let d = Double(comparandString) else { return nil }
+            return .number(d)
+        case "strings":
+            return .strings(comparandString
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty })
+        default:
+            return .string(comparandString)
+        }
+    }
+}
+
+// Make OperatorDescriptor Identifiable for ForEach
+extension OperatorDescriptor: Identifiable {}

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -83,6 +83,22 @@ struct CreateRuleView: View {
         sensorID == "com.controlplane.sensors.bluetooth"
     }
 
+    private var isRunningApplication: Bool {
+        sensorID == "com.controlplane.sensors.runningapplication"
+    }
+
+    /// All regular user-facing applications currently running, sorted by display name.
+    private var runningUserApps: [(name: String, bundleID: String)] {
+        NSWorkspace.shared.runningApplications
+            .compactMap { app -> (String, String)? in
+                guard app.activationPolicy == .regular,
+                      let name = app.localizedName,
+                      let bid  = app.bundleIdentifier else { return nil }
+                return (name, bid)
+            }
+            .sorted { $0.0 < $1.0 }
+    }
+
     /// Per-MAC readings from the Bluetooth snapshot (excludes the "devices" and "powered" keys).
     private var bluetoothDeviceReadings: [SensorReading] {
         guard isBluetooth, let snap = selectedSnapshot else { return [] }
@@ -106,6 +122,11 @@ struct CreateRuleView: View {
         if let r = selectedReading { return store.valueType(r.value) }
         // All current dynamic sensors emit booleans
         if isDynamic { return "boolean" }
+        // When editing an existing rule whose reading is not currently present
+        // (e.g. a mounted volume that is unmounted, or a USB device not connected),
+        // preserve the comparand type from the stored rule rather than falling back
+        // to "string" — a type mismatch causes equals() to return false at eval time.
+        if let existing = existingRule { return store.valueType(existing.comparand) }
         return "string"
     }
 
@@ -186,6 +207,8 @@ struct CreateRuleView: View {
             Section {
                 if isBluetooth {
                     bluetoothDevicePicker
+                } else if isRunningApplication {
+                    runningApplicationPicker
                 } else if isDynamic {
                     dynamicKeyField
                 } else if let snap = selectedSnapshot {
@@ -243,6 +266,42 @@ struct CreateRuleView: View {
                 }
             }
         }
+    }
+
+    /// Picker of currently running regular (user-facing) applications.
+    /// The rule's readingKey is the bundle identifier; we show the localised app name.
+    @ViewBuilder
+    private var runningApplicationPicker: some View {
+        let apps = runningUserApps
+        if apps.isEmpty {
+            Text("No user applications are currently running")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        } else {
+            Picker("Application", selection: $readingKey) {
+                Text("Choose…").tag("")
+                ForEach(apps, id: \.bundleID) { app in
+                    Text(app.name).tag(app.bundleID)
+                }
+            }
+            .onChange(of: readingKey) { _ in
+                resetBelowKey()
+                if !readingKey.isEmpty {
+                    comparandString = "true"
+                    seedOperator()
+                }
+            }
+        }
+
+        // Always show the bundle ID — acts as a display label when picked from the list,
+        // and as a manual-entry fallback for apps that are not currently running.
+        LabeledContent("Bundle ID") {
+            TextField("com.apple.safari", text: $readingKey)
+                .textFieldStyle(.roundedBorder)
+        }
+        Text("Only running apps appear in the list above. Type a bundle ID directly for apps that are not currently open.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
     }
 
     /// Free-text entry for dynamic sensors (the key IS the path / bundle ID / hostname).
@@ -336,28 +395,83 @@ struct CreateRuleView: View {
 
     // MARK: - Comparand field
 
+    /// Friendly true/false labels for the boolean comparand picker, tailored to each sensor.
+    private var booleanLabels: (trueLabel: String, falseLabel: String) {
+        switch sensorID {
+        case "com.controlplane.sensors.networklink":
+            return ("Connected", "Not connected")
+        case "com.controlplane.sensors.bluetooth":
+            // "powered" key describes the adapter state; MAC keys describe device connections.
+            return readingKey == "powered"
+                ? ("Powered on", "Powered off")
+                : ("Connected", "Not connected")
+        case "com.controlplane.sensors.usb":
+            return ("Connected", "Not connected")
+        case "com.controlplane.sensors.mountedvolume":
+            return ("Mounted", "Not mounted")
+        case "com.controlplane.sensors.filepresence":
+            return ("Present", "Not present")
+        case "com.controlplane.sensors.runningapplication":
+            return ("Running", "Not running")
+        case "com.controlplane.sensors.hostavailability":
+            return ("Reachable", "Not reachable")
+        case "com.controlplane.sensors.screenlock":
+            return ("Locked", "Unlocked")
+        case "com.controlplane.sensors.laptoplid":
+            return ("Closed", "Open")
+        case "com.controlplane.sensors.power":
+            return ("Yes", "No")
+        default:
+            return ("true", "false")
+        }
+    }
+
+    /// Fixed options for string readings whose values come from a closed set.
+    /// Returns nil when the reading accepts free-form text.
+    private var enumeratedStringOptions: [(label: String, value: String)]? {
+        switch (sensorID, readingKey) {
+        case ("com.controlplane.sensors.power", "source"):
+            return [("AC Power (plugged in)", "ac"),
+                    ("Battery (unplugged)",   "battery")]
+        default:
+            return nil
+        }
+    }
+
     @ViewBuilder
     private var comparandField: some View {
-        switch valueType {
-        case "boolean":
+        if let options = enumeratedStringOptions {
+            // Closed-set string reading — show a radio-style picker instead of a text field.
             Picker("Value", selection: $comparandString) {
-                Text("true  (exists / running / reachable)").tag("true")
-                Text("false (absent / stopped / unreachable)").tag("false")
+                ForEach(options, id: \.value) { opt in
+                    Text(opt.label).tag(opt.value)
+                }
             }
             .pickerStyle(.radioGroup)
-            .onAppear { if comparandString.isEmpty { comparandString = "true" } }
+            .onAppear { if comparandString.isEmpty { comparandString = options.first?.value ?? "" } }
+        } else {
+            switch valueType {
+            case "boolean":
+                let labels = booleanLabels
+                Picker("Value", selection: $comparandString) {
+                    Text(labels.trueLabel).tag("true")
+                    Text(labels.falseLabel).tag("false")
+                }
+                .pickerStyle(.radioGroup)
+                .onAppear { if comparandString.isEmpty { comparandString = "true" } }
 
-        case "number":
-            LabeledContent("Value") {
-                TextField("e.g. 42", text: $comparandString)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 120)
-            }
+            case "number":
+                LabeledContent("Value") {
+                    TextField("e.g. 42", text: $comparandString)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 120)
+                }
 
-        default: // string, strings
-            LabeledContent("Value") {
-                TextField("e.g. MyWifi", text: $comparandString)
-                    .textFieldStyle(.roundedBorder)
+            default: // string, strings
+                LabeledContent("Value") {
+                    TextField("e.g. MyWifi", text: $comparandString)
+                        .textFieldStyle(.roundedBorder)
+                }
             }
         }
     }

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -9,6 +9,10 @@ import ControlPlaneSDK
 /// Dynamic sensors (FilePresence, RunningApplication, HostAvailability, USB)
 /// don't emit readings until rules reference them. For those sensors the
 /// reading key is entered as free text (with a Browse button for FilePresence).
+///
+/// Bluetooth is special: it IS dynamic but emits per-MAC readings for every
+/// paired device. Those readings are shown as a device picker with a live
+/// connected/disconnected indicator instead of a free-text MAC address field.
 struct CreateRuleView: View {
 
     let profile: Profile
@@ -35,19 +39,32 @@ struct CreateRuleView: View {
         sensorID == "com.controlplane.sensors.filepresence"
     }
 
+    private var isBluetooth: Bool {
+        sensorID == "com.controlplane.sensors.bluetooth"
+    }
+
+    /// Per-MAC readings from the Bluetooth snapshot (excludes the "devices" and "powered" keys).
+    private var bluetoothDeviceReadings: [SensorReading] {
+        guard isBluetooth, let snap = selectedSnapshot else { return [] }
+        return snap.readings.filter { $0.key != "devices" && $0.key != "powered" }
+    }
+
     private var selectedSnapshot: SensorSnapshot? {
         store.snapshot(for: sensorID)
     }
 
     private var selectedReading: SensorReading? {
-        guard !isDynamic else { return nil }
+        // Bluetooth and other dynamic sensors: look up by key in snapshot
+        if isDynamic {
+            return selectedSnapshot?.readings.first { $0.key == readingKey }
+        }
         return selectedSnapshot?.readings.first { $0.key == readingKey }
     }
 
     /// The ObservationValue type string for the current reading.
     private var valueType: String {
         if let r = selectedReading { return store.valueType(r.value) }
-        // Dynamic sensors always emit booleans (file exists, app running, host reachable…)
+        // All current dynamic sensors emit booleans
         if isDynamic { return "boolean" }
         return "string"
     }
@@ -121,12 +138,64 @@ struct CreateRuleView: View {
     private var readingKeySection: some View {
         if !sensorID.isEmpty {
             Section {
-                if isDynamic {
+                if isBluetooth {
+                    bluetoothDevicePicker
+                } else if isDynamic {
                     dynamicKeyField
                 } else if let snap = selectedSnapshot {
                     staticKeyPicker(snap)
                 }
             } header: { Text("Reading") }
+        }
+    }
+
+    /// Picker showing all paired Bluetooth devices with a live connected/disconnected indicator.
+    @ViewBuilder
+    private var bluetoothDevicePicker: some View {
+        if bluetoothDeviceReadings.isEmpty {
+            Text("No paired Bluetooth devices found")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        } else {
+            Picker("Device", selection: $readingKey) {
+                Text("Choose…").tag("")
+                ForEach(bluetoothDeviceReadings, id: \.key) { reading in
+                    let isConnected = reading.value == .boolean(true)
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(isConnected ? Color.green : Color.secondary.opacity(0.4))
+                            .frame(width: 8, height: 8)
+                        Text(reading.label)
+                        Text(reading.key)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(isConnected ? "Connected" : "Not connected")
+                            .font(.caption)
+                            .foregroundStyle(isConnected ? .green : .secondary)
+                    }
+                    .tag(reading.key)
+                }
+            }
+            .onChange(of: readingKey) { _ in
+                resetBelowKey()
+                comparandString = "true"
+                seedOperator()
+            }
+
+            if !readingKey.isEmpty {
+                let device = bluetoothDeviceReadings.first { $0.key == readingKey }
+                let isConnected = device?.value == .boolean(true)
+                LabeledContent("Status") {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(isConnected ? Color.green : Color.secondary.opacity(0.4))
+                            .frame(width: 8, height: 8)
+                        Text(isConnected ? "Currently connected" : "Not currently connected")
+                            .foregroundStyle(isConnected ? .primary : .secondary)
+                    }
+                }
+            }
         }
     }
 

--- a/Sources/ControlPlaneApp/PreferencesView.swift
+++ b/Sources/ControlPlaneApp/PreferencesView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Root view for the Preferences window. Hosts a tab picker for Sensors and Profiles.
+struct PreferencesView: View {
+
+    @StateObject private var store: ControlPlaneStore
+
+    init(store: ControlPlaneStore) {
+        _store = StateObject(wrappedValue: store)
+    }
+
+    var body: some View {
+        TabView {
+            SensorsTabView(store: store)
+                .tabItem { Label("Sensors", systemImage: "waveform") }
+
+            ProfilesTabView(store: store)
+                .tabItem { Label("Profiles", systemImage: "person.2") }
+        }
+        .frame(minWidth: 700, minHeight: 450)
+        .task { await store.refresh() }
+        .alert("Error", isPresented: Binding(
+            get: { store.errorMessage != nil },
+            set: { if !$0 { store.errorMessage = nil } }
+        )) {
+            Button("OK") { store.errorMessage = nil }
+        } message: {
+            if let msg = store.errorMessage { Text(msg) }
+        }
+    }
+}

--- a/Sources/ControlPlaneApp/PreferencesWindowController.swift
+++ b/Sources/ControlPlaneApp/PreferencesWindowController.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+
+/// Manages the single Preferences window. Call `show(store:)` from any context —
+/// it opens the window if not already visible, or brings it to front if it is.
+@MainActor
+final class PreferencesWindowController: NSWindowController, NSWindowDelegate {
+
+    private static var shared: PreferencesWindowController?
+
+    static func show(store: ControlPlaneStore) {
+        if shared == nil {
+            let hostingController = NSHostingController(rootView: PreferencesView(store: store))
+            let window = NSWindow(contentViewController: hostingController)
+            window.title = "ControlPlane"
+            window.setContentSize(NSSize(width: 900, height: 620))
+            window.minSize = NSSize(width: 700, height: 450)
+            window.styleMask = [.titled, .closable, .resizable, .miniaturizable]
+            window.center()
+            window.isReleasedWhenClosed = false
+
+            let controller = PreferencesWindowController(window: window)
+            window.delegate = controller
+            shared = controller
+        }
+
+        shared?.showWindow(nil)
+        shared?.window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        PreferencesWindowController.shared = nil
+    }
+}

--- a/Sources/ControlPlaneApp/ProfileDetailView.swift
+++ b/Sources/ControlPlaneApp/ProfileDetailView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Detail panel for a single selected profile: metadata editor + Rules/Actions tabs.
+struct ProfileDetailView: View {
+
+    let profile: Profile
+    @ObservedObject var store: ControlPlaneStore
+
+    @State private var editName: String
+    @State private var editThreshold: Double
+    @State private var editExclusive: Bool
+    @State private var detailTab = 0
+
+    init(profile: Profile, store: ControlPlaneStore) {
+        self.profile = profile
+        self.store = store
+        _editName      = State(initialValue: profile.name)
+        _editThreshold = State(initialValue: profile.confidenceThreshold)
+        _editExclusive = State(initialValue: profile.exclusive)
+    }
+
+    private var rules:   [Rule]          { store.rules(for: profile.id) }
+    private var actions: [ProfileAction] { store.actions(for: profile.id) }
+    private var isActive: Bool           { store.isActive(profile.id) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            TabView(selection: $detailTab) {
+                RulesListView(profile: profile, store: store)
+                    .tabItem { Text("Rules (\(rules.count))") }
+                    .tag(0)
+                ActionsListView(profile: profile, store: store)
+                    .tabItem { Text("Actions (\(actions.count))") }
+                    .tag(1)
+            }
+        }
+        // Sync local editing state when the profile prop changes (different profile selected)
+        .onChange(of: profile.id) { _ in
+            editName      = profile.name
+            editThreshold = profile.confidenceThreshold
+            editExclusive = profile.exclusive
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 20) {
+            // Editable fields
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Name:")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 80, alignment: .trailing)
+                    TextField("Profile name", text: $editName)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 220)
+                        .onSubmit { saveIfChanged() }
+                }
+
+                HStack {
+                    Text("Threshold:")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 80, alignment: .trailing)
+                    Slider(value: $editThreshold, in: 0.1...5.0, step: 0.1)
+                        .frame(maxWidth: 180)
+                    Text(String(format: "%.1f", editThreshold))
+                        .monospacedDigit()
+                        .frame(width: 36, alignment: .leading)
+                }
+
+                HStack {
+                    Text("")
+                        .frame(width: 80, alignment: .trailing)
+                    Toggle("Exclusive", isOn: $editExclusive)
+                        .onChange(of: editExclusive) { _ in saveIfChanged() }
+                }
+            }
+
+            Spacer()
+
+            // Status badge
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(isActive ? Color.green : Color.secondary.opacity(0.4))
+                        .frame(width: 10, height: 10)
+                    Text(isActive ? "Active" : "Inactive")
+                        .font(.callout)
+                        .foregroundStyle(isActive ? .primary : .secondary)
+                }
+                if let conf = store.confidence(for: profile.id) {
+                    Text(String(format: "Confidence: %.2f", conf))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if editName != profile.name || editThreshold != profile.confidenceThreshold {
+                Button("Save") { saveIfChanged() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            }
+        }
+        .padding()
+    }
+
+    private func saveIfChanged() {
+        let trimmed = editName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        Task {
+            await store.updateProfile(
+                profile,
+                name: trimmed,
+                confidenceThreshold: editThreshold,
+                exclusive: editExclusive
+            )
+        }
+    }
+}

--- a/Sources/ControlPlaneApp/ProfileDetailView.swift
+++ b/Sources/ControlPlaneApp/ProfileDetailView.swift
@@ -37,12 +37,6 @@ struct ProfileDetailView: View {
                     .tag(1)
             }
         }
-        // Sync local editing state when the profile prop changes (different profile selected)
-        .onChange(of: profile.id) { _ in
-            editName      = profile.name
-            editThreshold = profile.confidenceThreshold
-            editExclusive = profile.exclusive
-        }
     }
 
     // MARK: - Header

--- a/Sources/ControlPlaneApp/ProfileDetailView.swift
+++ b/Sources/ControlPlaneApp/ProfileDetailView.swift
@@ -86,11 +86,7 @@ struct ProfileDetailView: View {
                         .font(.callout)
                         .foregroundStyle(isActive ? .primary : .secondary)
                 }
-                if let conf = store.confidence(for: profile.id) {
-                    Text(String(format: "Confidence: %.2f", conf))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                confidenceBadge
             }
 
             if editName != profile.name || editThreshold != profile.confidenceThreshold {
@@ -100,6 +96,24 @@ struct ProfileDetailView: View {
             }
         }
         .padding()
+    }
+
+    /// Shows current combined confidence vs the activation threshold.
+    /// Visible at all times so the user can see how close a profile is to activating.
+    private var confidenceBadge: some View {
+        let current   = store.currentConfidence(for: profile.id)
+        let threshold = profile.confidenceThreshold
+        let fraction  = threshold > 0 ? current / threshold : 0
+
+        let color: Color = isActive   ? .green
+                         : fraction >= 0.5 ? .orange
+                         : .secondary
+
+        return Text(String(format: "%.2f / %.2f", current, threshold))
+            .font(.caption)
+            .monospacedDigit()
+            .foregroundStyle(color)
+            .help("Current confidence / required threshold")
     }
 
     private func saveIfChanged() {

--- a/Sources/ControlPlaneApp/ProfilesTabView.swift
+++ b/Sources/ControlPlaneApp/ProfilesTabView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Top-level Profiles tab: profile list on the left, detail (rules + actions) on the right.
+struct ProfilesTabView: View {
+
+    @ObservedObject var store: ControlPlaneStore
+    @State private var selectedProfileID: UUID?
+    @State private var showingCreateProfile = false
+
+    private var selectedProfile: Profile? {
+        store.profiles.first { $0.id == selectedProfileID }
+    }
+
+    var body: some View {
+        HSplitView {
+            profileList
+                .frame(minWidth: 180, maxWidth: 240)
+
+            if let profile = selectedProfile {
+                ProfileDetailView(profile: profile, store: store)
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "person.2")
+                        .font(.system(size: 40))
+                        .foregroundStyle(.secondary)
+                    Text(store.profiles.isEmpty
+                         ? "Add a profile to get started"
+                         : "Select a profile")
+                        .foregroundStyle(.secondary)
+                    if store.profiles.isEmpty {
+                        Button("Add Profile") { showingCreateProfile = true }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .sheet(isPresented: $showingCreateProfile) {
+            CreateProfileView { name, threshold, exclusive in
+                Task {
+                    await store.createProfile(
+                        name: name,
+                        confidenceThreshold: threshold,
+                        exclusive: exclusive
+                    )
+                    // Select the new profile automatically
+                    selectedProfileID = store.profiles.last?.id
+                }
+            }
+        }
+    }
+
+    // MARK: - Profile list
+
+    private var profileList: some View {
+        VStack(spacing: 0) {
+            List(store.profiles, id: \.id, selection: $selectedProfileID) { profile in
+                profileRow(profile)
+                    .contextMenu {
+                        Button("Delete Profile", role: .destructive) {
+                            Task {
+                                await store.deleteProfile(profile)
+                                if selectedProfileID == profile.id {
+                                    selectedProfileID = nil
+                                }
+                            }
+                        }
+                    }
+            }
+            Divider()
+            HStack(spacing: 0) {
+                Button(action: { showingCreateProfile = true }) {
+                    Image(systemName: "plus")
+                        .frame(width: 28, height: 24)
+                }
+                .buttonStyle(.borderless)
+
+                Button(action: {
+                    guard let profile = selectedProfile else { return }
+                    Task {
+                        await store.deleteProfile(profile)
+                        selectedProfileID = nil
+                    }
+                }) {
+                    Image(systemName: "minus")
+                        .frame(width: 28, height: 24)
+                }
+                .buttonStyle(.borderless)
+                .disabled(selectedProfile == nil)
+
+                Spacer()
+            }
+            .padding(.horizontal, 2)
+            .padding(.vertical, 2)
+        }
+    }
+
+    @ViewBuilder
+    private func profileRow(_ profile: Profile) -> some View {
+        let active = store.isActive(profile.id)
+        let conf   = store.confidence(for: profile.id)
+
+        HStack(spacing: 6) {
+            Circle()
+                .fill(active ? Color.green : Color.secondary.opacity(0.3))
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(profile.name)
+                    .fontWeight(active ? .semibold : .regular)
+                    .lineLimit(1)
+                if let conf {
+                    Text(String(format: "%.2f confidence", conf))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 1)
+    }
+}
+
+// MARK: - Create Profile Sheet
+
+struct CreateProfileView: View {
+    let onSave: (String, Double, Bool) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var threshold = 1.0
+    @State private var exclusive = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("New Profile")
+                .font(.headline)
+
+            Form {
+                TextField("Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+
+                LabeledContent("Confidence Threshold") {
+                    HStack {
+                        Slider(value: $threshold, in: 0.1...5.0, step: 0.1)
+                        Text(String(format: "%.1f", threshold))
+                            .frame(width: 36, alignment: .trailing)
+                            .monospacedDigit()
+                    }
+                }
+
+                Toggle("Exclusive (deactivates other profiles)", isOn: $exclusive)
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add") {
+                    onSave(name, threshold, exclusive)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+    }
+}

--- a/Sources/ControlPlaneApp/ProfilesTabView.swift
+++ b/Sources/ControlPlaneApp/ProfilesTabView.swift
@@ -19,6 +19,7 @@ struct ProfilesTabView: View {
 
             if let profile = selectedProfile {
                 ProfileDetailView(profile: profile, store: store)
+                    .id(profile.id)   // force fresh view (and fresh @State) on selection change
             } else {
                 VStack(spacing: 8) {
                     Image(systemName: "person.2")

--- a/Sources/ControlPlaneApp/RuleEngine.swift
+++ b/Sources/ControlPlaneApp/RuleEngine.swift
@@ -18,6 +18,15 @@ actor RuleEngine {
     /// Populated after each `evaluate(snapshots:)` call.
     private(set) var currentRuleMatches: [UUID: Bool] = [:]
 
+    /// Called after every evaluation with the latest rule-match state and
+    /// per-profile confidence scores (including profiles below their threshold).
+    /// Keyed by rule / profile UUID respectively.
+    private var onEvaluated: (@Sendable ([UUID: Bool], [UUID: Double]) -> Void)?
+
+    func setOnEvaluated(_ callback: @escaping @Sendable ([UUID: Bool], [UUID: Double]) -> Void) {
+        onEvaluated = callback
+    }
+
     init(
         ruleStore: RuleStore,
         profileStore: ProfileStore,
@@ -57,7 +66,10 @@ actor RuleEngine {
         var ruleMatches: [UUID: Bool] = [:]
 
         for rule in rules where rule.enabled {
-            guard let snapshot = snapshotIndex[rule.sensorID] else { continue }
+            guard let snapshot = snapshotIndex[rule.sensorID] else {
+                log("[RuleEngine] rule '\(rule.name)' — no snapshot for sensor \(rule.sensorID), skipping")
+                continue
+            }
             let reading = snapshot.readings.first(where: { $0.key == rule.readingKey })?.value
 
             guard let evaluator = await evaluatorRegistry.evaluator(for: rule.evaluatorID) else {
@@ -69,6 +81,8 @@ actor RuleEngine {
             // Apply negation: a negated rule contributes when the condition is absent.
             let matched = rule.negate ? !rawMatch : rawMatch
             ruleMatches[rule.id] = matched
+
+            log("[RuleEngine] rule '\(rule.name)' — key='\(rule.readingKey)' reading=\(String(describing: reading)) op=\(rule.operatorID) comparand=\(rule.comparand) negate=\(rule.negate) → matched=\(matched)")
 
             if matched {
                 let current = unconfidence[rule.profileID, default: 1.0]
@@ -82,11 +96,28 @@ actor RuleEngine {
         let active = unconfidence.compactMap { (profileID, unc) -> ActiveProfile? in
             let score = 1.0 - unc
             guard let profile = profileIndex[profileID],
-                  score >= profile.confidenceThreshold else { return nil }
+                  score >= profile.confidenceThreshold else {
+                let name = profileIndex[profileID]?.name ?? profileID.uuidString
+                log("[RuleEngine] profile '\(name)' — confidence \(1.0 - unc) below threshold \(profileIndex[profileID]?.confidenceThreshold ?? -1), not activating")
+                return nil
+            }
             return ActiveProfile(profile: profile, confidence: score)
         }.sorted { $0.confidence > $1.confidence }
 
         currentActiveProfiles = active
+
+        // Build a confidence score for every profile, defaulting to 0.0 for profiles
+        // that had no matching rules (their unconfidence entry was never written).
+        // This lets the UI show progress toward the threshold even for inactive profiles.
+        if let callback = onEvaluated {
+            var profileConfidences: [UUID: Double] = [:]
+            for profile in profiles {
+                let unc = unconfidence[profile.id, default: 1.0]
+                profileConfidences[profile.id] = 1.0 - unc
+            }
+            callback(ruleMatches, profileConfidences)
+        }
+
         return active
     }
 }

--- a/Sources/ControlPlaneApp/RulesListView.swift
+++ b/Sources/ControlPlaneApp/RulesListView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import ControlPlaneSDK
+
+/// Lists the rules attached to a profile, with controls to add / remove / toggle.
+struct RulesListView: View {
+
+    let profile: Profile
+    @ObservedObject var store: ControlPlaneStore
+
+    @State private var selectedRuleIDs = Set<UUID>()
+    @State private var showingCreateRule = false
+
+    private var rules: [Rule] { store.rules(for: profile.id) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if rules.isEmpty {
+                emptyState
+            } else {
+                ruleTable
+            }
+            Divider()
+            toolbar
+        }
+        .sheet(isPresented: $showingCreateRule) {
+            CreateRuleView(profile: profile, store: store) {
+                // nothing extra on save
+            }
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "text.badge.plus")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text("No rules for this profile")
+                .foregroundStyle(.secondary)
+            Button("Add Rule") { showingCreateRule = true }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Table
+
+    private var ruleTable: some View {
+        Table(rules, selection: $selectedRuleIDs) {
+            TableColumn("") { rule in
+                Toggle("", isOn: Binding(
+                    get: { rule.enabled },
+                    set: { enabled in Task { await store.setRuleEnabled(rule, enabled: enabled) } }
+                ))
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+            }
+            .width(24)
+
+            TableColumn("Name") { rule in
+                Text(rule.name).lineLimit(1)
+            }
+
+            TableColumn("Sensor") { rule in
+                Text(store.snapshot(for: rule.sensorID)?.displayName ?? rule.sensorID)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            TableColumn("Condition") { rule in
+                HStack(spacing: 4) {
+                    if rule.negate {
+                        Text("NOT").font(.caption).foregroundStyle(.orange)
+                    }
+                    Text(rule.readingKey)
+                        .font(.system(.body, design: .monospaced))
+                    Text(operatorLabel(rule.operatorID))
+                        .foregroundStyle(.secondary)
+                    Text(rule.comparand.description)
+                        .font(.system(.body, design: .monospaced))
+                }
+                .lineLimit(1)
+            }
+
+            TableColumn("Weight") { rule in
+                Text(String(format: "%.1f", rule.weight))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .width(50)
+        }
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            Button("Delete", role: .destructive) {
+                let toDelete = rules.filter { ids.contains($0.id) }
+                Task {
+                    for rule in toDelete {
+                        await store.deleteRule(rule)
+                    }
+                    selectedRuleIDs.removeAll()
+                }
+            }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 0) {
+            Button(action: { showingCreateRule = true }) {
+                Image(systemName: "plus").frame(width: 28, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .help("Add rule")
+
+            Button(action: {
+                let toDelete = rules.filter { selectedRuleIDs.contains($0.id) }
+                Task {
+                    for rule in toDelete { await store.deleteRule(rule) }
+                    selectedRuleIDs.removeAll()
+                }
+            }) {
+                Image(systemName: "minus").frame(width: 28, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .disabled(selectedRuleIDs.isEmpty)
+            .help("Remove selected rules")
+
+            Spacer()
+
+            Text("\(rules.count) rule\(rules.count == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.trailing, 8)
+        }
+        .padding(.horizontal, 2)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Helpers
+
+    private func operatorLabel(_ id: String) -> String {
+        store.operators.first { $0.id == id }?.label ?? id
+    }
+}

--- a/Sources/ControlPlaneApp/RulesListView.swift
+++ b/Sources/ControlPlaneApp/RulesListView.swift
@@ -68,6 +68,11 @@ struct RulesListView: View {
             }
             .width(24)
 
+            TableColumn("") { rule in
+                matchIndicator(for: rule)
+            }
+            .width(20)
+
             TableColumn("Name") { rule in
                 Text(rule.name).lineLimit(1)
             }
@@ -170,6 +175,26 @@ struct RulesListView: View {
 
     private func operatorLabel(_ id: String) -> String {
         store.operators.first { $0.id == id }?.label ?? id
+    }
+
+    /// Small SF-Symbol dot indicating whether this rule is currently matching.
+    /// Disabled rules show nothing; enabled rules show green (match) or red (no match).
+    /// A dashed circle is shown before the first evaluation result arrives.
+    @ViewBuilder
+    private func matchIndicator(for rule: Rule) -> some View {
+        if !rule.enabled {
+            // Disabled rules contribute nothing — don't show a state indicator.
+            Color.clear
+        } else if let matched = store.ruleMatches[rule.id] {
+            Image(systemName: matched ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundStyle(matched ? .green : .red)
+                .help(matched ? "Rule is currently matching" : "Rule is not matching")
+        } else {
+            // No evaluation result yet (app just launched or rule just created).
+            Image(systemName: "circle.dotted")
+                .foregroundStyle(.tertiary)
+                .help("Awaiting evaluation")
+        }
     }
 }
 

--- a/Sources/ControlPlaneApp/RulesListView.swift
+++ b/Sources/ControlPlaneApp/RulesListView.swift
@@ -1,16 +1,26 @@
 import SwiftUI
+import AppKit
 import ControlPlaneSDK
 
-/// Lists the rules attached to a profile, with controls to add / remove / toggle.
+/// Lists the rules attached to a profile, with controls to add / edit / remove / toggle.
 struct RulesListView: View {
 
     let profile: Profile
     @ObservedObject var store: ControlPlaneStore
 
-    @State private var selectedRuleIDs = Set<UUID>()
+    @State private var selectedRuleIDs  = Set<UUID>()
     @State private var showingCreateRule = false
+    @State private var editingRule: Rule? = nil
 
     private var rules: [Rule] { store.rules(for: profile.id) }
+
+    /// The single selected rule, or nil if zero or more than one row is selected.
+    private var singleSelection: Rule? {
+        guard selectedRuleIDs.count == 1,
+              let id = selectedRuleIDs.first
+        else { return nil }
+        return rules.first { $0.id == id }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,9 +33,10 @@ struct RulesListView: View {
             toolbar
         }
         .sheet(isPresented: $showingCreateRule) {
-            CreateRuleView(profile: profile, store: store) {
-                // nothing extra on save
-            }
+            CreateRuleView(profile: profile, store: store)
+        }
+        .sheet(item: $editingRule) { rule in
+            CreateRuleView(profile: profile, store: store, existingRule: rule)
         }
     }
 
@@ -90,16 +101,25 @@ struct RulesListView: View {
             .width(50)
         }
         .contextMenu(forSelectionType: UUID.self) { ids in
+            if ids.count == 1, let rule = rules.first(where: { ids.contains($0.id) }) {
+                Button("Edit Rule") { editingRule = rule }
+                Divider()
+            }
             Button("Delete", role: .destructive) {
                 let toDelete = rules.filter { ids.contains($0.id) }
                 Task {
-                    for rule in toDelete {
-                        await store.deleteRule(rule)
-                    }
+                    for rule in toDelete { await store.deleteRule(rule) }
                     selectedRuleIDs.removeAll()
                 }
             }
         }
+        // Double-click: sets the NSTableView's doubleAction via an invisible background view.
+        .background(
+            TableDoubleClickHandler {
+                guard let rule = singleSelection else { return }
+                editingRule = rule
+            }
+        )
     }
 
     // MARK: - Toolbar
@@ -125,6 +145,16 @@ struct RulesListView: View {
             .disabled(selectedRuleIDs.isEmpty)
             .help("Remove selected rules")
 
+            Button(action: {
+                guard let rule = singleSelection else { return }
+                editingRule = rule
+            }) {
+                Image(systemName: "pencil").frame(width: 28, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .disabled(singleSelection == nil)
+            .help("Edit selected rule")
+
             Spacer()
 
             Text("\(rules.count) rule\(rules.count == 1 ? "" : "s")")
@@ -140,5 +170,51 @@ struct RulesListView: View {
 
     private func operatorLabel(_ id: String) -> String {
         store.operators.first { $0.id == id }?.label ?? id
+    }
+}
+
+// MARK: - Double-click handler
+
+/// Invisible background view that walks up to the enclosing NSTableView and
+/// wires its doubleAction to our closure.
+private struct TableDoubleClickHandler: NSViewRepresentable {
+
+    let onDoubleClick: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.onDoubleClick = onDoubleClick
+        return NSView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onDoubleClick = onDoubleClick
+        // Schedule on the next run-loop pass so the view is in the hierarchy.
+        DispatchQueue.main.async {
+            guard let tableView = nsView.enclosingTableView else { return }
+            tableView.doubleAction = #selector(Coordinator.handleDoubleClick(_:))
+            tableView.target = context.coordinator
+        }
+    }
+
+    final class Coordinator: NSObject {
+        var onDoubleClick: (() -> Void)?
+
+        @objc func handleDoubleClick(_ sender: Any?) {
+            onDoubleClick?()
+        }
+    }
+}
+
+private extension NSView {
+    /// Walk the superview chain to find the nearest enclosing NSTableView.
+    var enclosingTableView: NSTableView? {
+        var view: NSView? = superview
+        while let v = view {
+            if let table = v as? NSTableView { return table }
+            view = v.superview
+        }
+        return nil
     }
 }

--- a/Sources/ControlPlaneApp/SensorCoordinator.swift
+++ b/Sources/ControlPlaneApp/SensorCoordinator.swift
@@ -58,10 +58,21 @@ actor SensorCoordinator {
 
     /// Fire the snapshot callback with the current snapshots from all sensors.
     /// Called by PushSensor callbacks and by refreshAllSensors.
+    ///
+    /// The callback is awaited directly (not wrapped in a new Task) so that
+    /// successive calls from rapid sensor events — e.g. unmount immediately
+    /// followed by remount — are serialised through the actor and evaluated in
+    /// the order they arrived.  Spawning an unstructured Task here caused the
+    /// unmount evaluation to sometimes win a race against the remount evaluation
+    /// at the RuleEngine actor, leaving the profile incorrectly deactivated.
     func triggerSnapshotCallback() async {
-        guard let onChange = onSnapshotsUpdated else { return }
+        guard let onChange = onSnapshotsUpdated else {
+            log("[SensorCoordinator] triggerSnapshotCallback — onSnapshotsUpdated is nil, skipping")
+            return
+        }
         let snapshots = await allSnapshots()
-        Task { await onChange(snapshots) }
+        log("[SensorCoordinator] triggerSnapshotCallback — evaluating with \(snapshots.count) snapshots")
+        await onChange(snapshots)
     }
 
     /// Ask every sensor to re-read hardware state — called after location authorization changes.

--- a/Sources/ControlPlaneApp/SensorsTabView.swift
+++ b/Sources/ControlPlaneApp/SensorsTabView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import ControlPlaneSDK
+
+// MARK: - Protocol extensions for SwiftUI conformance
+
+extension SensorReading: Identifiable {
+    public var id: String { key }
+}
+
+// MARK: - View
+
+/// Displays all loaded sensors and the live readings for the selected one.
+struct SensorsTabView: View {
+
+    @ObservedObject var store: ControlPlaneStore
+    @State private var selectedSensorID: String?
+
+    var body: some View {
+        HSplitView {
+            sensorList
+                .frame(minWidth: 190, maxWidth: 260)
+
+            if let id = selectedSensorID, let snapshot = store.snapshot(for: id) {
+                sensorDetail(snapshot)
+            } else {
+                Text("Select a sensor to view its readings")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear {
+            if selectedSensorID == nil {
+                selectedSensorID = store.snapshots.first?.sensorID
+            }
+        }
+        .onChange(of: store.snapshots.count) { _ in
+            // Keep selection valid when snapshots update
+            if let id = selectedSensorID, store.snapshot(for: id) == nil {
+                selectedSensorID = store.snapshots.first?.sensorID
+            }
+        }
+    }
+
+    // MARK: - Sensor list
+
+    private var sensorList: some View {
+        VStack(spacing: 0) {
+            List(store.snapshots, id: \.sensorID, selection: $selectedSensorID) { snapshot in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(snapshot.isActive ? Color.green : Color.secondary.opacity(0.4))
+                        .frame(width: 8, height: 8)
+                    Text(snapshot.displayName)
+                        .lineLimit(1)
+                }
+                .contentShape(Rectangle())
+            }
+            Divider()
+            HStack {
+                Text("\(store.snapshots.count) sensors")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button(action: { Task { await store.refreshSnapshots() } }) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .help("Refresh sensor readings")
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Sensor detail
+
+    private func sensorDetail(_ snapshot: SensorSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(snapshot.displayName).font(.headline)
+                    Text(snapshot.sensorID).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(snapshot.isActive ? Color.green : Color.secondary.opacity(0.4))
+                        .frame(width: 8, height: 8)
+                    Text(snapshot.isActive ? "Active" : "Inactive")
+                        .font(.caption)
+                        .foregroundStyle(snapshot.isActive ? .primary : .secondary)
+                }
+            }
+            .padding()
+
+            Divider()
+
+            if snapshot.readings.isEmpty {
+                Text("No readings available")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Table(snapshot.readings) {
+                    TableColumn("Key") { r in
+                        Text(r.key)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    TableColumn("Label") { r in
+                        Text(r.label)
+                    }
+                    TableColumn("Value") { r in
+                        Text(r.value.description)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                }
+            }
+
+            Divider()
+            Text("Captured: \(snapshot.capturedAt.formatted(date: .omitted, time: .complete))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+                .padding(.vertical, 6)
+        }
+    }
+}

--- a/Sources/ControlPlaneApp/main.swift
+++ b/Sources/ControlPlaneApp/main.swift
@@ -4,6 +4,9 @@ import AppKit
 setbuf(stdout, nil)
 
 let app = NSApplication.shared
-let delegate = AppDelegate()
+// AppDelegate is @MainActor; main.swift runs on the main thread at startup,
+// so MainActor.assumeIsolated satisfies the isolation requirement without
+// changing runtime behaviour.
+let delegate = MainActor.assumeIsolated { AppDelegate() }
 app.delegate = delegate
 app.run()

--- a/Sources/Sensors/Bluetooth/BluetoothSensor.swift
+++ b/Sources/Sensors/Bluetooth/BluetoothSensor.swift
@@ -104,17 +104,25 @@ public final class BluetoothSensor: BaseSensor, DynamicKeySensor {
 
     private func refreshSnapshot() {
         let paired    = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] ?? []
-        let connected = paired.filter { $0.isConnected() }
-        let names     = connected.compactMap { $0.name }
+        let connected = Set(paired.filter { $0.isConnected() }.compactMap { $0.addressString })
+        let connectedNames = paired.filter { $0.isConnected() }.compactMap { $0.name }
         let powered   = IOBluetoothHostController.default()?.powerState == kBluetoothHCIPowerStateON
 
         var readings: [SensorReading] = [
-            SensorReading(key: "devices", label: "Connected Devices", value: .strings(names)),
+            SensorReading(key: "devices", label: "Connected Devices", value: .strings(connectedNames)),
             SensorReading(key: "powered", label: "Bluetooth Powered",  value: .boolean(powered)),
         ]
-        for device in connected {
+        // Emit one reading per paired device — connected (true) or not (false).
+        // This lets rules target any paired device, not just currently connected ones,
+        // and gives the UI a full device list with live connection status.
+        for device in paired {
             if let addr = device.addressString {
-                readings.append(SensorReading(key: addr, label: device.name ?? addr, value: .boolean(true)))
+                let isConnected = connected.contains(addr)
+                readings.append(SensorReading(
+                    key: addr,
+                    label: device.name ?? addr,
+                    value: .boolean(isConnected)
+                ))
             }
         }
         publishSnapshot(readings: readings)

--- a/Sources/Sensors/MountedVolume/MountedVolumeSensor.swift
+++ b/Sources/Sensors/MountedVolume/MountedVolumeSensor.swift
@@ -19,14 +19,18 @@ public final class MountedVolumeSensor: BaseSensor {
             forName: NSWorkspace.didMountNotification,
             object: nil,
             queue: nil
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            let path = (notification.userInfo?["NSDevicePath"] as? String) ?? "unknown"
+            NSLog("[MountedVolume] didMountNotification — path: %@", path)
             DispatchQueue.main.async { self?.refreshSnapshot() }
         }
         unmountObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didUnmountNotification,
             object: nil,
             queue: nil
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            let path = (notification.userInfo?["NSDevicePath"] as? String) ?? "unknown"
+            NSLog("[MountedVolume] didUnmountNotification — path: %@", path)
             DispatchQueue.main.async { self?.refreshSnapshot() }
         }
         DispatchQueue.main.sync { refreshSnapshot() }
@@ -50,6 +54,7 @@ public final class MountedVolumeSensor: BaseSensor {
             options: []
         ) ?? []
         let names = urls.map { $0.lastPathComponent }
+        NSLog("[MountedVolume] refreshSnapshot — volumes: %@", names.joined(separator: ", "))
         var readings: [SensorReading] = [
             SensorReading(key: "mounted", label: "Mounted Volumes", value: .strings(names))
         ]

--- a/docs/gui-plan.md
+++ b/docs/gui-plan.md
@@ -1,0 +1,279 @@
+# ControlPlane — Final GUI Plan
+
+This document captures the agreed design for the final ControlPlane GUI. It is a living
+reference — update it as decisions are made during workshopping. Sections marked
+**[OPEN]** still need decisions.
+
+---
+
+## 1. Menu Bar
+
+### Current state
+- Airplane SF Symbol icon on the left.
+- Icon title updates to show active profile names (`" Home, Work"`).
+- Menu contains: header, separator, Preferences…, Run Action flyout, separator,
+  active profile list (disabled labels), separator, Quit.
+
+### Target state
+
+**Add a Profiles flyout** (same pattern as the existing Run Action flyout):
+
+```
+ControlPlane
+────────────
+Settings…           ⌘,
+────────────
+Profiles ▶          ← NEW flyout
+  ○  Home           ← all profiles, inactive = hollow dot
+  ●  Work           ← active (rule-engine) = filled dot
+  🔒 VPN Override   ← manually locked = lock icon
+Run Action ▶
+────────────
+● Work              ← active profiles summary (unchanged)
+────────────
+Quit ControlPlane   ⌘Q
+```
+
+**Manual override / "sticky" profiles**
+
+Selecting a profile from the Profiles flyout manually activates it and marks it
+**locked** until the user explicitly deactivates it. This implements Issue #521.
+
+Rules:
+- A locked profile stays active regardless of what the rule engine determines.
+- The rule engine continues running normally; its results still govern
+  non-locked profiles.
+- A locked profile is shown with a lock icon (🔒) in the flyout.
+- Clicking a locked profile in the flyout **removes the lock** and hands
+  control back to the rule engine (which may immediately deactivate it).
+- If the rule engine independently activates a profile that is also locked,
+  that is fine — it remains active from both sources.
+- Multiple profiles can be locked simultaneously.
+
+**Implementation notes**
+- `ProfileActivationManager` needs a `lockedProfiles: Set<UUID>` concept.
+  Locked profiles are always included in the active set, merged with
+  rule-engine results before callbacks fire.
+- `AppDelegate` routes the flyout item click to
+  `profileActivationManager.toggleLock(profileID:)`.
+- The flyout item for each profile shows:
+  - Current rule-engine active state (dot)
+  - Locked state (lock icon, appended or replacing dot)
+  - Profile name
+
+**[OPEN]** Does locking a profile persist across app restarts, or is it
+session-only? Suggested: session-only by default, with a "Keep locked after
+restart" checkbox accessible via right-click on the locked item in the flyout.
+
+---
+
+## 2. Settings Window — Overall Structure
+
+Rename "Preferences" → "Settings" (follows Apple HIG; tracked in Issue #540).
+
+### Tab order (Profiles is the default/first tab)
+
+| # | Tab | SF Symbol | Notes |
+|---|-----|-----------|-------|
+| 1 | **Profiles** | `person.2` | Default tab. Profile list + rule configuration. |
+| 2 | **Actions** | `bolt` | Global action library (new architecture). |
+| 3 | **Sensors** | `waveform` | Existing sensor config tab (unchanged). |
+| 4 | **General** | `gear` | App-level settings: logging level (#543), launch at login, etc. |
+
+---
+
+## 3. Profiles Tab
+
+### Layout
+
+Three-panel horizontal split view:
+
+```
+┌──────────────┬────────────────────────┬──────────────────────┐
+│ Profile list │  Profile detail        │  Rules for profile   │
+│              │  (name, threshold,     │                      │
+│ ○ Home       │   confidence badge)    │  [match] Rule name   │
+│ ● Work  ←sel │                        │  [match] Rule name   │
+│ ○ Weekend    │                        │  [match] Rule name   │
+│              │                        │  …                   │
+│ [+] [−]      │  Actions assigned:     │                      │
+│              │  • Open Safari (act.)  │                      │
+│              │  • Run Script  (deact) │  [+] [−] [✏]        │
+└──────────────┴────────────────────────┴──────────────────────┘
+```
+
+**Panel 1 — Profile list (left, ~200 px)**
+- Each row: active/inactive dot + profile name + current confidence score
+  (shown as `0.84 / 1.00` using the live `profileConfidences` data — same as
+  the current sidebar).
+- Locked profiles get an additional 🔒 indicator.
+- `[+]` / `[−]` toolbar buttons at the bottom.
+- Right-click context menu: Rename, Delete, Duplicate **[OPEN]**.
+
+**Panel 2 — Profile detail (centre, fixed ~280 px)**
+- Editable name field (save on Return / focus-out).
+- Confidence threshold slider (same as current).
+- Exclusive toggle.
+- Live confidence badge: `0.84 / 1.00` coloured green/orange/grey.
+- **Assigned actions list** — a compact, read-only list of actions linked to
+  this profile, showing action display name + trigger (on activate /
+  on deactivate). Each row has a small `×` to remove the link.
+  An `[+ Add Action]` button opens a sheet to link an action from the global
+  library (see §4).
+
+**Panel 3 — Rules (right, fills remaining space)**
+- Identical to the current `RulesListView` including the live match-state
+  column and the `[+]` / `[−]` / `[✏]` toolbar.
+- No inner tabs — rules live directly in this panel.
+
+**[OPEN]** Should the three-panel split be resizable or should panel 2 have a
+fixed width? Suggested: panel 1 and 2 fixed, panel 3 fills.
+
+**[OPEN]** Where does the "Duplicate profile" feature live? Useful for creating
+a variant of an existing profile. Right-click context menu is the natural place.
+
+---
+
+## 4. Actions Tab (New Architecture)
+
+### Motivation
+
+Currently `ProfileAction` is always tied to a specific profile via `profileID`.
+This means the same logical action (e.g., "connect to VPN") must be created
+separately for every profile that needs it. The new architecture separates
+action *definitions* from profile *assignments*:
+
+- **`Action`** — a named, reusable action: type + configuration, no profile
+  affiliation.
+- **`ProfileActionLink`** — joins a profile to an action: `profileID`,
+  `actionID`, `trigger` (on activate / on deactivate), `enabled`.
+
+A single `Action` record can be linked to many profiles with the same or
+different triggers.
+
+### Tab layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Actions                                                    │
+├──────────────────────────────────────────────────────────────┤
+│  Type          Name                   Used by               │
+│  ──────────    ──────────────────     ──────────────────    │
+│  Shell Script  Connect VPN            Work, Travel          │
+│  Open URL      Open Dashboard         Home                  │
+│  Speak         Say Good Morning       Home, Weekend         │
+│  …                                                          │
+│                                                             │
+│ [+] [−] [✏]                                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- Each row: action type icon, display name, comma-separated list of profiles
+  it is assigned to.
+- `[+]` opens `CreateActionView` (type picker + config form, no profile
+  assignment here — that happens from the Profiles tab).
+- `[−]` deletes the selected action; warns if it is linked to one or more
+  profiles.
+- `[✏]` / double-click edits the action definition.
+- **[OPEN]** Whether a "Run now" button belongs here for testing actions
+  manually (analogous to the existing "Run Action" menu flyout).
+
+### Linking actions to profiles
+
+From **Panel 2** of the Profiles tab, clicking `[+ Add Action]`:
+1. Opens a sheet listing all actions in the global library.
+2. User picks one (or creates a new one inline).
+3. User specifies the trigger: **On Activate** or **On Deactivate**.
+4. The link is saved as a `ProfileActionLink` record.
+
+### Database migration
+
+This requires a schema change:
+
+```sql
+-- New table: action definitions (no profile affiliation)
+CREATE TABLE actions (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    actionPluginID  TEXT NOT NULL,
+    config          TEXT NOT NULL DEFAULT '{}',   -- JSON
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    createdAt       TEXT NOT NULL,
+    updatedAt       TEXT NOT NULL
+);
+
+-- New table: profile ↔ action links (replaces profileActions)
+CREATE TABLE profileActionLinks (
+    id          TEXT PRIMARY KEY,
+    profileID   TEXT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    actionID    TEXT NOT NULL REFERENCES actions(id)  ON DELETE CASCADE,
+    trigger     TEXT NOT NULL,   -- "onActivate" | "onDeactivate"
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    createdAt   TEXT NOT NULL
+);
+```
+
+The old `profileActions` table is dropped. No data migration is needed or desired.
+
+**Decision: wipe on schema change, no migration.**
+`AppDatabase` already sets `migrator.eraseDatabaseOnSchemaChange = true` in
+`#if DEBUG` builds. Adding the new migrations will automatically drop and
+recreate the entire database the next time the app launches. This is the correct
+behaviour for a pre-release app with a single developer. When the app eventually
+ships publicly, a proper migration path can be added at that time.
+
+---
+
+## 5. Sensors Tab
+
+Unchanged from current implementation. Displays all loaded sensors, their current
+snapshot readings, and per-sensor configuration (where applicable). Remains the
+third tab.
+
+---
+
+## 6. General Tab (New)
+
+Collects app-level settings currently scattered or missing:
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| Launch at login | Off | Standard `SMAppService` / `LaunchAgent` |
+| Logging level | Off | Issue #543 — Off / Info / Debug |
+| Show in Dock while Settings open | Off | Issue #540 |
+| Notification style | Banner | Profile activate/deactivate notifications |
+| **[OPEN]** Check interval override | — | For sensors that poll |
+
+---
+
+## 7. Deferred / Out of Scope for Initial GUI
+
+These items are tracked as separate issues and are **not** part of the initial
+GUI implementation sprint:
+
+| Feature | Issue |
+|---------|-------|
+| Time of Day calendar-style rule editor | #544 |
+| USB device name picker | #545 |
+| Wi-Fi network scan + picker | #546 |
+| Running Application picker (done) | — |
+| Power source dropdown (done) | — |
+| Structured logging UI | #543 |
+| Dock icon while Settings open | #540 |
+| Host Availability ping replacement | #539 |
+| Manual profile override (menu lock) | #521 (implemented in §1 above) |
+| Auto-update | #522 |
+| Code signing / notarization | #523 |
+
+---
+
+## 8. Open Questions Summary
+
+1. Does locking a profile persist across restarts?
+2. Should Panel 2 (profile detail) have a fixed width or be resizable?
+3. Where does "Duplicate profile" live in the UI?
+4. Does the Actions tab need a "Run now" test button?
+5. ~~Migrate or wipe existing `profileActions` data on schema change?~~ **Decided: wipe. `eraseDatabaseOnSchemaChange = true` already handles this in DEBUG builds.**
+6. Should the Sensors tab move to position 3, or stay where it is?
+7. **[OPEN]** Should the window have a minimum size change to accommodate the
+   three-panel Profiles layout? Current minimum is 700 × 450.


### PR DESCRIPTION
## Summary

Full SwiftUI settings window plus a collection of rule engine bug fixes and UX improvements made during GUI testing. This branch is ready to ship as the baseline GUI.

### Settings window
- **Sensors tab** — live list of all loaded sensors with a detail panel showing current readings, auto-refreshing every 2 seconds.
- **Profiles tab** — full CRUD for profiles (name, confidence threshold, exclusive flag) with a split-view: profile list on the left, rules table and actions panel on the right.
- **Rules panel** — table with enable/disable toggles, add/edit/delete (minus button, pencil button, double-click, context menu). Guided create/edit sheet: pick sensor → reading key → operator → comparand → weight.
- **Actions panel** — same layout as rules; create sheet picks action type → trigger → fills dynamic config fields from each plugin's `configDescriptors`.
- **Run Action flyout** in the menu bar for manually triggering actions during testing.
- **ControlPlaneStore** — `@MainActor` `ObservableObject` bridging the actor-based backend to SwiftUI. `AppDelegate` observes `store.$activeProfiles` via Combine.

### Rule creation UX improvements
- **Sensor-aware boolean labels**: "Connected / Not connected" for Network Link and USB, "Mounted / Not mounted" for volumes, "Running / Not running" for applications, "Reachable / Not reachable" for host availability, "Locked / Unlocked" for screen lock, "Closed / Open" for laptop lid, etc.
- **Power sensor source picker**: radio buttons showing "AC Power (plugged in)" / "Battery (unplugged)" instead of a free-text field.
- **Running Application picker**: live list of running user-facing apps by display name (same filter as Activity Monitor), with a bundle ID text field fallback for apps not currently open.
- **Bluetooth device picker**: lists all paired devices with a live connected/disconnected indicator.

### Bug fixes
- **Comparand type mismatch** (critical): when editing a rule whose sensor reading is not currently present (e.g. a mounted volume rule edited while the volume is unmounted), the comparand type was incorrectly inferred as `string` instead of preserving the existing rule's type. This caused `equals(.boolean(true), .string("true"))` → `false`, breaking the rule permanently until manually re-saved. Fixed by falling back to the existing rule's comparand type.
- **Race condition in snapshot evaluation**: `triggerSnapshotCallback` was spawning an unstructured `Task { await onChange(...) }`, allowing rapid sensor events (e.g. unmount immediately followed by remount) to be evaluated out of order. Fixed by awaiting the callback directly so events are serialised through the actor.
- **Rule changes not taking effect immediately**: `refreshDynamicSensorKeys` only triggered re-evaluation via sensor side-effects. Now explicitly calls `triggerSnapshotCallback` after updating keys so negate toggles, weight changes, and enable/disable take effect at once.
- **Retroactive `Identifiable` conformance** compile error in `RulesListView` removed.

### Live diagnostics (rule match indicators)
- `RuleEngine` fires an `onEvaluated` callback after every evaluation, emitting per-rule match state (`[UUID: Bool]`) and per-profile confidence scores including inactive profiles (`[UUID: Double]`).
- `ControlPlaneStore` publishes `ruleMatches` and `profileConfidences`; UI updates live without polling.
- **Rules table**: new match-state column — green checkmark (matching), red × (not matching), dashed circle (awaiting first evaluation), blank (disabled).
- **Profile header**: always shows `current / threshold` confidence (e.g. `0.84 / 1.00`), coloured green (active), orange (≥50% of threshold but not yet active), grey (below 50%). Previously only shown when the profile was already active.

### Friendly interface names (merged from #542)
- `NetworkLinkSensor` and `IPAddressSensor` now use localised interface names ("Wi-Fi", "Thunderbolt Ethernet") as reading labels. Keys are unchanged so existing rules are unaffected.

### Docs
- `docs/gui-plan.md` — living design reference for the final GUI (also in PR #547 targeting main directly).

## Test plan

- [ ] `make run` compiles and launches cleanly
- [ ] Sensors tab shows all loaded sensors with live readings
- [ ] Profiles tab: create, edit name/threshold, delete
- [ ] Rules: add a rule, verify match indicator updates live; toggle enabled; edit; delete
- [ ] Power sensor rule shows AC Power / Battery radio picker
- [ ] Running Application rule shows app picker populated from running apps
- [ ] Mounted Volume rule edited while volume is unmounted still evaluates correctly after remount
- [ ] Profile header shows confidence score even when profile is inactive
- [ ] Actions: add, toggle, delete
- [ ] Menu bar Run Action flyout lists configured actions
- [ ] Menu bar shows active profile name(s)

Closes #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
