### PR TITLE
Use friendly interface names in IP Address and Network Link sensors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,10 @@ let package = Package(
 
         .target(
             name: "ControlPlaneSDK",
-            path: "Sources/ControlPlaneSDK"
+            path: "Sources/ControlPlaneSDK",
+            linkerSettings: [
+                .linkedFramework("SystemConfiguration"),
+            ]
         ),
 
         // MARK: - Sensor plugins

--- a/Sources/ControlPlaneSDK/NetworkInterfaceNames.swift
+++ b/Sources/ControlPlaneSDK/NetworkInterfaceNames.swift
@@ -1,0 +1,41 @@
+import SystemConfiguration
+
+/// Builds a mapping of BSD interface name (e.g. `"en0"`) to a user-friendly
+/// display label (e.g. `"Wi-Fi"`), using the localised names that macOS shows
+/// in System Settings → Network.
+///
+/// When two interfaces share the same localised name (e.g. two Thunderbolt
+/// Ethernet adapters), the BSD name is appended in parentheses so the user
+/// can tell them apart: `"Ethernet (en2)"`.
+///
+/// Interfaces with no localised name (loopback, VPN tunnels, etc.) are
+/// represented by their BSD name unchanged.
+///
+/// Both `IPAddressSensor` and `NetworkLinkSensor` call this at snapshot refresh
+/// time to populate `SensorReading.label` with friendly names while leaving
+/// `SensorReading.key` as the raw BSD name so existing rules are unaffected.
+public func buildFriendlyInterfaceNames() -> [String: String] {
+    let ifaces = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] ?? []
+
+    // First pass: collect bsdName → localised display name.
+    var raw: [(bsd: String, friendly: String)] = []
+    for iface in ifaces {
+        guard let bsd = SCNetworkInterfaceGetBSDName(iface) as? String else { continue }
+        let friendly = SCNetworkInterfaceGetLocalizedDisplayName(iface) as? String ?? bsd
+        raw.append((bsd: bsd, friendly: friendly))
+    }
+
+    // Find friendly names that appear more than once.
+    var counts: [String: Int] = [:]
+    for entry in raw { counts[entry.friendly, default: 0] += 1 }
+
+    var result: [String: String] = [:]
+    for entry in raw {
+        if counts[entry.friendly]! > 1 {
+            result[entry.bsd] = "\(entry.friendly) (\(entry.bsd))"
+        } else {
+            result[entry.bsd] = entry.friendly
+        }
+    }
+    return result
+}

--- a/Sources/Sensors/IPAddress/IPAddressSensor.swift
+++ b/Sources/Sensors/IPAddress/IPAddressSensor.swift
@@ -56,6 +56,7 @@ public final class IPAddressSensor: BaseSensor {
     private func refreshSnapshot() {
         guard let store else { return }
 
+        let friendlyNames = buildFriendlyInterfaceNames()
         var readings: [SensorReading] = []
         var allAddresses: [String] = []
         var ifaceAddresses: [String: (ipv4: String, ipv6: String)] = [:]
@@ -89,10 +90,12 @@ public final class IPAddressSensor: BaseSensor {
         }
 
         for (iface, addrs) in ifaceAddresses {
-            readings.append(SensorReading(key: "\(iface).ipv4", label: "\(iface) IPv4", value: .string(addrs.ipv4)))
-            readings.append(SensorReading(key: "\(iface).ipv6", label: "\(iface) IPv6", value: .string(addrs.ipv6)))
+            let base = friendlyNames[iface] ?? iface
+            readings.append(SensorReading(key: "\(iface).ipv4", label: "\(base) (IPv4)", value: .string(addrs.ipv4)))
+            readings.append(SensorReading(key: "\(iface).ipv6", label: "\(base) (IPv6)", value: .string(addrs.ipv6)))
         }
         readings.append(SensorReading(key: "allAddresses", label: "All Addresses", value: .strings(allAddresses)))
         publishSnapshot(readings: readings)
     }
+
 }

--- a/Sources/Sensors/NetworkLink/NetworkLinkSensor.swift
+++ b/Sources/Sensors/NetworkLink/NetworkLinkSensor.swift
@@ -58,6 +58,7 @@ public final class NetworkLinkSensor: BaseSensor {
         let pattern = "State:/Network/Interface/.*/Link" as CFString
         let keys = SCDynamicStoreCopyKeyList(store, pattern) as? [String] ?? []
 
+        let friendlyNames = buildFriendlyInterfaceNames()
         var readings: [SensorReading] = []
         var activeInterfaces: [String] = []
 
@@ -71,7 +72,8 @@ public final class NetworkLinkSensor: BaseSensor {
                let active = val["Active"] as? Bool {
                 isActive = active
             }
-            readings.append(SensorReading(key: iface, label: iface, value: .boolean(isActive)))
+            let label = friendlyNames[iface] ?? iface
+            readings.append(SensorReading(key: iface, label: label, value: .boolean(isActive)))
             if isActive { activeInterfaces.append(iface) }
         }
         readings.append(SensorReading(key: "activeInterfaces", label: "Active Interfaces", value: .strings(activeInterfaces)))


### PR DESCRIPTION
## Summary

Closes #541.

- `IPAddressSensor` and `NetworkLinkSensor` previously showed raw BSD interface names (`en0`, `en1`) as the human-visible label in the rule picker
- A new shared helper `buildFriendlyInterfaceNames()` in `ControlPlaneSDK` uses `SCNetworkInterfaceCopyAll` + `SCNetworkInterfaceGetLocalizedDisplayName` to map BSD names to the localised display names shown in System Settings → Network
- Rule picker now shows `Wi-Fi (IPv4)` instead of `en0 IPv4`, `Ethernet` instead of `en1`, etc.
- When two interfaces share the same friendly name, the BSD name is appended: `Ethernet (en2)`
- `SensorReading.key` is **unchanged** — existing rules stored as `en0.ipv4` continue to evaluate correctly with no migration needed

## Test plan

- [ ] Open Preferences → any profile → Rules → Add Rule → select IP Address sensor — reading picker shows friendly names (e.g. `Wi-Fi (IPv4)`) not BSD names
- [ ] Same check for Network Link sensor — readings show `Wi-Fi`, `Ethernet`, etc.
- [ ] An existing rule created before this change (if any) still evaluates correctly
- [ ] `swift build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)