### PR TITLE
Structured logging with os.Logger (issue #543)

### DIFF
--- a/Sources/ControlPlaneApp/ActionRegistry.swift
+++ b/Sources/ControlPlaneApp/ActionRegistry.swift
@@ -7,7 +7,7 @@ actor ActionRegistry {
 
     func register(_ plugin: any ActionPlugin) {
         plugins[plugin.pluginIdentifier] = plugin
-        log("Action plugin registered: \(plugin.pluginIdentifier)")
+        log("Action plugin registered: \(plugin.pluginIdentifier)", CPLogger.plugins)
     }
 
     func plugin(for id: String) -> (any ActionPlugin)? {

--- a/Sources/ControlPlaneApp/AppDatabase.swift
+++ b/Sources/ControlPlaneApp/AppDatabase.swift
@@ -29,7 +29,7 @@ final class AppDatabase {
         let queue = try DatabaseQueue(path: dbURL.path, configuration: config)
         let appDB = AppDatabase(queue)
         try appDB.runMigrations()
-        log("Database open: \(dbURL.path)")
+        log("Database open: \(dbURL.path)", CPLogger.setup)
         return appDB
     }
 

--- a/Sources/ControlPlaneApp/AppDelegate.swift
+++ b/Sources/ControlPlaneApp/AppDelegate.swift
@@ -51,8 +51,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         center.delegate = self
         center.removeAllPendingNotificationRequests()
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if let error { log("Notification authorization error: \(error)") }
-            log("Notification permission: \(granted ? "granted" : "denied")")
+            if let error { logError("Notification authorization error: \(error)", CPLogger.setup) }
+            log("Notification permission: \(granted ? "granted" : "denied")", CPLogger.setup)
             if granted { Notifier.startup() }
         }
     }
@@ -185,19 +185,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor [weak self] in
             guard let self else { return }
             guard let profile = self.store.profiles.first(where: { $0.id == action.profileID }) else {
-                log("Run Action: profile \(action.profileID) not found")
+                log("Run Action: profile \(action.profileID) not found", CPLogger.actions)
                 return
             }
             guard let plugin = await self.backend.actionRegistry.plugin(for: action.actionPluginID) else {
-                log("Run Action: plugin '\(action.actionPluginID)' not loaded")
+                log("Run Action: plugin '\(action.actionPluginID)' not loaded", CPLogger.actions)
                 return
             }
             do {
-                log("Run Action: executing \(action.actionPluginID) [\(action.trigger.rawValue)] for \"\(profile.name)\"")
+                log("Run Action: executing \(action.actionPluginID) [\(action.trigger.rawValue)] for \"\(profile.name)\"", CPLogger.actions)
                 try await plugin.execute(trigger: action.trigger, profile: profile, config: action.config)
-                log("Run Action: done")
+                log("Run Action: done", CPLogger.actions)
             } catch {
-                log("Run Action failed: \(error)")
+                logError("Run Action failed: \(error)", CPLogger.actions)
             }
         }
     }

--- a/Sources/ControlPlaneApp/Backend.swift
+++ b/Sources/ControlPlaneApp/Backend.swift
@@ -75,7 +75,7 @@ final class Backend {
     }
 
     func start() {
-        log("Starting ControlPlane backend (pid \(ProcessInfo.processInfo.processIdentifier))")
+        log("Starting ControlPlane backend (pid \(ProcessInfo.processInfo.processIdentifier))", CPLogger.general)
         locationAuthorizer.onAuthorized = { [weak self] in
             guard let self else { return }
             Task { await self.sensorCoordinator.refreshAllSensors() }
@@ -95,11 +95,11 @@ final class Backend {
                     let active = try await self.ruleEngine.evaluate(snapshots: snapshots)
                     await self.profileActivationManager.update(active)
                 } catch {
-                    log("Rule evaluation error: \(error)")
+                    logError("Rule evaluation error: \(error)", CPLogger.rules)
                 }
             }
         }
-        log("Backend ready")
+        log("Backend ready", CPLogger.general)
     }
 
     private func registerStaticEvaluators() {
@@ -187,7 +187,7 @@ final class Backend {
                 await sensorCoordinator.setMonitoredKeys(keys, forSensor: id)
             }
         } catch {
-            log("refreshDynamicSensorKeys error: \(error)")
+            logError("refreshDynamicSensorKeys error: \(error)", CPLogger.rules)
         }
         // Force an evaluation with current snapshots so that rule edits (negate
         // toggle, weight change, enable/disable) take effect immediately regardless
@@ -197,7 +197,7 @@ final class Backend {
 
     private func registerSensor(_ sensor: any SensorPlugin) async {
         guard type(of: sensor).isApplicable() else {
-            log("Sensor \(sensor.pluginIdentifier) is not applicable on this system — skipping")
+            log("Sensor \(sensor.pluginIdentifier) is not applicable on this system — skipping", CPLogger.sensors)
             return
         }
         let info = PluginInfo(
@@ -227,11 +227,8 @@ final class Backend {
         let server = SocketServer(handler: handler)
         server.start()
         socketServer = server
-        log("Socket server active at \(CPSocketPath)")
+        log("Socket server active at \(CPSocketPath)", CPLogger.socket)
     }
 }
 
-func log(_ message: String) {
-    let ts = ISO8601DateFormatter().string(from: Date())
-    print("[\(ts)] [ControlPlane] \(message)")
-}
+// log() / logDebug() / logError() are defined in CPLogger.swift

--- a/Sources/ControlPlaneApp/CPLogger.swift
+++ b/Sources/ControlPlaneApp/CPLogger.swift
@@ -1,0 +1,72 @@
+import os
+
+// MARK: - Log Level
+
+enum CPLogLevel: Int, Comparable, CaseIterable {
+    case off   = 0
+    case info  = 1
+    case debug = 2
+
+    static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+
+    var label: String {
+        switch self {
+        case .off:   return "Off"
+        case .info:  return "Info"
+        case .debug: return "Debug"
+        }
+    }
+}
+
+// MARK: - Logger namespace
+
+enum CPLogger {
+    static let subsystem = "com.controlplane.app"
+
+    /// General / uncategorised app events
+    static let general  = Logger(subsystem: subsystem, category: "General")
+    /// Sensor lifecycle and snapshot callbacks
+    static let sensors  = Logger(subsystem: subsystem, category: "Sensors")
+    /// Rule evaluation detail
+    static let rules    = Logger(subsystem: subsystem, category: "RuleEngine")
+    /// Profile activation and profile-store CRUD
+    static let profiles = Logger(subsystem: subsystem, category: "Profiles")
+    /// Action execution and action-store CRUD
+    static let actions  = Logger(subsystem: subsystem, category: "Actions")
+    /// Plugin / bundle loading
+    static let plugins  = Logger(subsystem: subsystem, category: "Plugins")
+    /// Unix-socket server
+    static let socket   = Logger(subsystem: subsystem, category: "Socket")
+    /// App setup: location auth, cpctl installer, database
+    static let setup    = Logger(subsystem: subsystem, category: "Setup")
+
+    /// UserDefaults key for the persisted log level (stored as Int rawValue).
+    static let levelKey = "com.controlplane.logLevel"
+
+    /// The currently active log level, read from UserDefaults on every access so
+    /// changes in the Preferences UI take effect immediately without a restart.
+    static var activeLevel: CPLogLevel {
+        CPLogLevel(rawValue: UserDefaults.standard.integer(forKey: levelKey)) ?? .off
+    }
+}
+
+// MARK: - Global helpers
+
+/// Log an informational message. Gated by CPLogLevel.info (or higher).
+/// Drop-in replacement for the old print()-based log() function — existing call sites
+/// that omit the logger argument continue to work unchanged.
+func log(_ message: String, _ logger: Logger = CPLogger.general) {
+    guard CPLogger.activeLevel >= .info else { return }
+    logger.info("\(message, privacy: .public)")
+}
+
+/// Log a verbose / debug message. Only emitted at CPLogLevel.debug.
+func logDebug(_ message: String, _ logger: Logger = CPLogger.general) {
+    guard CPLogger.activeLevel >= .debug else { return }
+    logger.debug("\(message, privacy: .public)")
+}
+
+/// Log an error. Always emitted regardless of the active log level.
+func logError(_ message: String, _ logger: Logger = CPLogger.general) {
+    logger.error("\(message, privacy: .public)")
+}

--- a/Sources/ControlPlaneApp/CpctlInstaller.swift
+++ b/Sources/ControlPlaneApp/CpctlInstaller.swift
@@ -16,13 +16,13 @@ enum CpctlInstaller {
 
     static func installIfNeeded() {
         if FileManager.default.fileExists(atPath: installPath) {
-            log("cpctl already installed at \(installPath)")
+            log("cpctl already installed at \(installPath)", CPLogger.setup)
             return
         }
 
         // Bundle.main.path(forAuxiliaryExecutable:) resolves Contents/MacOS/<name>
         guard let bundled = Bundle.main.path(forAuxiliaryExecutable: "cpctl") else {
-            log("cpctl not found in app bundle — skipping auto-install")
+            log("cpctl not found in app bundle — skipping auto-install", CPLogger.setup)
             return
         }
 
@@ -34,13 +34,13 @@ enum CpctlInstaller {
             )
             try FileManager.default.copyItem(atPath: bundled, toPath: installPath)
             codesign(path: installPath)
-            log("cpctl installed to \(installPath)")
+            log("cpctl installed to \(installPath)", CPLogger.setup)
             Notifier.send(
                 title: "cpctl installed",
                 body: "Command-line tool is available at \(installPath)"
             )
         } catch {
-            log("cpctl auto-install failed: \(error)")
+            logError("cpctl auto-install failed: \(error)", CPLogger.setup)
         }
     }
 
@@ -55,7 +55,7 @@ enum CpctlInstaller {
         try? proc.run()
         proc.waitUntilExit()
         if proc.terminationStatus != 0 {
-            log("cpctl codesign exited \(proc.terminationStatus) — binary may still work")
+            log("cpctl codesign exited \(proc.terminationStatus) — binary may still work", CPLogger.setup)
         }
     }
 }

--- a/Sources/ControlPlaneApp/EvaluatorRegistry.swift
+++ b/Sources/ControlPlaneApp/EvaluatorRegistry.swift
@@ -7,7 +7,7 @@ actor EvaluatorRegistry {
 
     func register(_ evaluator: any EvaluatorPlugin) {
         evaluators[evaluator.pluginIdentifier] = evaluator
-        log("Evaluator registered: \(evaluator.pluginIdentifier)")
+        log("Evaluator registered: \(evaluator.pluginIdentifier)", CPLogger.plugins)
     }
 
     func evaluator(for id: String) -> (any EvaluatorPlugin)? {

--- a/Sources/ControlPlaneApp/GeneralSettingsView.swift
+++ b/Sources/ControlPlaneApp/GeneralSettingsView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import AppKit
+
+struct GeneralSettingsView: View {
+    @AppStorage("com.controlplane.logLevel") private var logLevelRaw: Int = CPLogLevel.off.rawValue
+
+    private var logLevel: Binding<CPLogLevel> {
+        Binding(
+            get: { CPLogLevel(rawValue: logLevelRaw) ?? .off },
+            set: { logLevelRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Log level:", selection: logLevel) {
+                    ForEach(CPLogLevel.allCases, id: \.self) { level in
+                        Text(level.label).tag(level)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 200)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Logs are written to the Apple Unified Log.")
+                        .foregroundStyle(.secondary)
+                    Text("To view them, open Console.app and filter by subsystem:")
+                        .foregroundStyle(.secondary)
+                    Text("com.controlplane.app")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                .font(.callout)
+
+                Button("Open Console.app") {
+                    NSWorkspace.shared.open(
+                        URL(fileURLWithPath: "/System/Applications/Utilities/Console.app")
+                    )
+                }
+                .buttonStyle(.borderless)
+            } header: {
+                Text("Logging")
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}
+
+#Preview {
+    GeneralSettingsView()
+        .frame(width: 500, height: 300)
+}

--- a/Sources/ControlPlaneApp/LocationAuthorizer.swift
+++ b/Sources/ControlPlaneApp/LocationAuthorizer.swift
@@ -19,12 +19,12 @@ final class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     func requestIfNeeded() {
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorized:
-            log("Location: already authorized")
+            log("Location: already authorized", CPLogger.setup)
         case .notDetermined:
-            log("Location: requesting authorization")
+            log("Location: requesting authorization", CPLogger.setup)
             manager.requestAlwaysAuthorization()
         case .denied, .restricted:
-            log("Location: denied — Wi-Fi SSID and network scan will be unavailable")
+            log("Location: denied — Wi-Fi SSID and network scan will be unavailable", CPLogger.setup)
         @unknown default:
             manager.requestAlwaysAuthorization()
         }
@@ -33,10 +33,10 @@ final class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorized:
-            log("Location: authorized")
+            log("Location: authorized", CPLogger.setup)
             onAuthorized?()
         case .denied, .restricted:
-            log("Location: denied — Wi-Fi SSID and network scan will be unavailable")
+            log("Location: denied — Wi-Fi SSID and network scan will be unavailable", CPLogger.setup)
         case .notDetermined:
             break
         @unknown default:

--- a/Sources/ControlPlaneApp/PluginLoader.swift
+++ b/Sources/ControlPlaneApp/PluginLoader.swift
@@ -24,11 +24,11 @@ final class PluginLoader {
     }
 
     func discoverPlugins() {
-        log("Plugin discovery starting")
+        log("Plugin discovery starting", CPLogger.plugins)
         for (directory, source) in searchDirectories() {
             load(from: directory, source: source)
         }
-        log("Plugin discovery complete")
+        log("Plugin discovery complete", CPLogger.plugins)
     }
 
     // MARK: - Private
@@ -57,7 +57,7 @@ final class PluginLoader {
     private func load(from directory: URL, source: PluginInfo.PluginSource) {
         let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else {
-            log("Plugin directory absent (skipping): \(directory.path)")
+            logDebug("Plugin directory absent (skipping): \(directory.path)", CPLogger.plugins)
             return
         }
 
@@ -69,12 +69,12 @@ final class PluginLoader {
                 options: .skipsHiddenFiles
             ).filter { $0.pathExtension == "bundle" }
         } catch {
-            log("Failed to read plugin directory \(directory.path): \(error.localizedDescription)")
+            logError("Failed to read plugin directory \(directory.path): \(error.localizedDescription)", CPLogger.plugins)
             return
         }
 
         if bundles.isEmpty {
-            log("No plugins in \(directory.path)")
+            logDebug("No plugins in \(directory.path)", CPLogger.plugins)
             return
         }
 
@@ -85,29 +85,29 @@ final class PluginLoader {
 
     private func loadBundle(at url: URL, source: PluginInfo.PluginSource) {
         guard let bundle = Bundle(url: url) else {
-            log("Could not create Bundle from \(url.lastPathComponent)")
+            logError("Could not create Bundle from \(url.lastPathComponent)", CPLogger.plugins)
             return
         }
 
         guard bundle.load() else {
-            log("Failed to load bundle \(url.lastPathComponent)")
+            logError("Failed to load bundle \(url.lastPathComponent)", CPLogger.plugins)
             return
         }
 
         guard let principalClass = bundle.principalClass else {
-            log("No NSPrincipalClass declared in \(url.lastPathComponent)")
+            logError("No NSPrincipalClass declared in \(url.lastPathComponent)", CPLogger.plugins)
             return
         }
 
         guard let objectType = principalClass as? NSObject.Type else {
-            log("Principal class in \(url.lastPathComponent) does not subclass NSObject")
+            logError("Principal class in \(url.lastPathComponent) does not subclass NSObject", CPLogger.plugins)
             return
         }
 
         let instance = objectType.init()
 
         guard let plugin = instance as? ControlPlanePlugin else {
-            log("Principal class in \(url.lastPathComponent) does not conform to ControlPlanePlugin")
+            logError("Principal class in \(url.lastPathComponent) does not conform to ControlPlanePlugin", CPLogger.plugins)
             return
         }
 
@@ -121,11 +121,11 @@ final class PluginLoader {
         switch rawCategory {
         case "sensor":
             guard let sensorPlugin = plugin as? (any SensorPlugin) else {
-                log("Plugin \(plugin.pluginIdentifier) declares category 'sensor' but does not conform to SensorPlugin")
+                logError("Plugin \(plugin.pluginIdentifier) declares category 'sensor' but does not conform to SensorPlugin", CPLogger.plugins)
                 return
             }
             guard type(of: sensorPlugin).isApplicable() else {
-                log("Sensor \(plugin.pluginIdentifier) is not applicable on this system — skipping")
+                log("Sensor \(plugin.pluginIdentifier) is not applicable on this system — skipping", CPLogger.plugins)
                 return
             }
             Task { await self.sensors.add(sensorPlugin) }
@@ -133,7 +133,7 @@ final class PluginLoader {
 
         case "action":
             guard plugin is ActionPlugin else {
-                log("Plugin \(plugin.pluginIdentifier) declares category 'action' but does not conform to ActionPlugin")
+                logError("Plugin \(plugin.pluginIdentifier) declares category 'action' but does not conform to ActionPlugin", CPLogger.plugins)
                 return
             }
             category = .action
@@ -142,7 +142,7 @@ final class PluginLoader {
             category = .intelligence
 
         default:
-            log("Unknown plugin category '\(rawCategory)' in \(plugin.pluginIdentifier)")
+            logError("Unknown plugin category '\(rawCategory)' in \(plugin.pluginIdentifier)", CPLogger.plugins)
             return
         }
 
@@ -156,6 +156,6 @@ final class PluginLoader {
 
         Task { await registry.register(info) }
 
-        log("Loaded \(rawCategory) plugin: \(plugin.pluginDisplayName) (\(plugin.pluginIdentifier)) v\(plugin.pluginVersion) [\(source.rawValue)]")
+        log("Loaded \(rawCategory) plugin: \(plugin.pluginDisplayName) (\(plugin.pluginIdentifier)) v\(plugin.pluginVersion) [\(source.rawValue)]", CPLogger.plugins)
     }
 }

--- a/Sources/ControlPlaneApp/PreferencesView.swift
+++ b/Sources/ControlPlaneApp/PreferencesView.swift
@@ -12,6 +12,9 @@ struct PreferencesView: View {
 
     var body: some View {
         TabView {
+            GeneralSettingsView()
+                .tabItem { Label("General", systemImage: "gear") }
+
             SensorsTabView(store: store)
                 .tabItem { Label("Sensors", systemImage: "waveform") }
 

--- a/Sources/ControlPlaneApp/ProfileActionStore.swift
+++ b/Sources/ControlPlaneApp/ProfileActionStore.swift
@@ -26,7 +26,7 @@ actor ProfileActionStore {
         )
         let record = try ProfileActionRecord(action)
         try await db.dbQueue.write { db in try record.insert(db) }
-        log("ProfileAction created: \(action.id) [\(trigger.rawValue)] plugin=\(actionPluginID)")
+        log("ProfileAction created: \(action.id) [\(trigger.rawValue)] plugin=\(actionPluginID)", CPLogger.actions)
         return action
     }
 
@@ -59,7 +59,7 @@ actor ProfileActionStore {
         )
         let record = try ProfileActionRecord(updated)
         try await db.dbQueue.write { db in try record.update(db) }
-        log("ProfileAction updated: \(id)")
+        log("ProfileAction updated: \(id)", CPLogger.actions)
         return updated
     }
 
@@ -70,7 +70,7 @@ actor ProfileActionStore {
             }
             try ProfileActionRecord.deleteOne(db, key: id.uuidString)
         }
-        log("ProfileAction deleted: \(id)")
+        log("ProfileAction deleted: \(id)", CPLogger.actions)
     }
 
     func list(forProfile profileID: UUID) async throws -> [ProfileAction] {

--- a/Sources/ControlPlaneApp/ProfileActivationManager.swift
+++ b/Sources/ControlPlaneApp/ProfileActivationManager.swift
@@ -34,14 +34,14 @@ actor ProfileActivationManager {
 
         // Fire actions after state is committed (suspension points are safe here).
         for ap in activated {
-            log("Profile activated: \"\(ap.profile.name)\" (confidence \(String(format: "%.2f", ap.confidence)))")
+            log("Profile activated: \"\(ap.profile.name)\" (confidence \(String(format: "%.2f", ap.confidence)))", CPLogger.profiles)
             try? await profileStore.recordActivation(ap.profile.id)
             Notifier.profileActivated(ap.profile)
             await runActions(for: ap.profile, trigger: .onActivate)
         }
 
         for ap in deactivated {
-            log("Profile deactivated: \"\(ap.profile.name)\"")
+            log("Profile deactivated: \"\(ap.profile.name)\"", CPLogger.profiles)
             try? await profileStore.recordDeactivation(ap.profile.id)
             Notifier.profileDeactivated(ap.profile)
             await runActions(for: ap.profile, trigger: .onDeactivate)
@@ -65,21 +65,21 @@ actor ProfileActivationManager {
         do {
             actions = try await actionStore.list(forProfile: profile.id)
         } catch {
-            log("Failed to load actions for profile \(profile.id): \(error)")
+            logError("Failed to load actions for profile \(profile.id): \(error)", CPLogger.profiles)
             return
         }
 
         for action in actions where action.enabled && action.trigger == trigger {
             guard let plugin = await actionRegistry.plugin(for: action.actionPluginID) else {
-                log("Action plugin '\(action.actionPluginID)' not loaded — skipping action \(action.id)")
+                log("Action plugin '\(action.actionPluginID)' not loaded — skipping action \(action.id)", CPLogger.actions)
                 continue
             }
             do {
                 try await plugin.execute(trigger: trigger, profile: profile, config: action.config)
                 try? await actionStore.recordTriggered(action.id)
-                log("Action \(action.id) [\(action.actionPluginID)] executed for \"\(profile.name)\"")
+                log("Action \(action.id) [\(action.actionPluginID)] executed for \"\(profile.name)\"", CPLogger.actions)
             } catch {
-                log("Action \(action.id) failed: \(error)")
+                logError("Action \(action.id) failed: \(error)", CPLogger.actions)
             }
         }
     }

--- a/Sources/ControlPlaneApp/ProfileStore.swift
+++ b/Sources/ControlPlaneApp/ProfileStore.swift
@@ -21,7 +21,7 @@ actor ProfileStore {
         let profile = Profile(name: name, parentID: parentID, exclusive: exclusive, confidenceThreshold: confidenceThreshold)
         let record = ProfileRecord(profile)
         try await db.dbQueue.write { db in try record.insert(db) }
-        log("Profile created: \(profile.id) \"\(profile.name)\"")
+        log("Profile created: \(profile.id) \"\(profile.name)\"", CPLogger.profiles)
         return profile
     }
 
@@ -50,7 +50,7 @@ actor ProfileStore {
         try await db.dbQueue.write { db in
             try record.update(db)
         }
-        log("Profile updated: \(id) \"\(updated.name)\"")
+        log("Profile updated: \(id) \"\(updated.name)\"", CPLogger.profiles)
         return updated
     }
 
@@ -61,7 +61,7 @@ actor ProfileStore {
             }
             try ProfileRecord.deleteOne(db, key: id.uuidString)
         }
-        log("Profile deleted: \(id)")
+        log("Profile deleted: \(id)", CPLogger.profiles)
     }
 
     func findByName(_ name: String) async throws -> Profile? {

--- a/Sources/ControlPlaneApp/RuleEngine.swift
+++ b/Sources/ControlPlaneApp/RuleEngine.swift
@@ -67,13 +67,13 @@ actor RuleEngine {
 
         for rule in rules where rule.enabled {
             guard let snapshot = snapshotIndex[rule.sensorID] else {
-                log("[RuleEngine] rule '\(rule.name)' — no snapshot for sensor \(rule.sensorID), skipping")
+                log("[RuleEngine] rule '\(rule.name)' — no snapshot for sensor \(rule.sensorID), skipping", CPLogger.rules)
                 continue
             }
             let reading = snapshot.readings.first(where: { $0.key == rule.readingKey })?.value
 
             guard let evaluator = await evaluatorRegistry.evaluator(for: rule.evaluatorID) else {
-                log("Warning: evaluator '\(rule.evaluatorID)' not found for rule \(rule.id) — skipping")
+                log("Warning: evaluator '\(rule.evaluatorID)' not found for rule \(rule.id) — skipping", CPLogger.rules)
                 continue
             }
 
@@ -82,7 +82,7 @@ actor RuleEngine {
             let matched = rule.negate ? !rawMatch : rawMatch
             ruleMatches[rule.id] = matched
 
-            log("[RuleEngine] rule '\(rule.name)' — key='\(rule.readingKey)' reading=\(String(describing: reading)) op=\(rule.operatorID) comparand=\(rule.comparand) negate=\(rule.negate) → matched=\(matched)")
+            logDebug("[RuleEngine] rule '\(rule.name)' — key='\(rule.readingKey)' reading=\(String(describing: reading)) op=\(rule.operatorID) comparand=\(rule.comparand) negate=\(rule.negate) → matched=\(matched)", CPLogger.rules)
 
             if matched {
                 let current = unconfidence[rule.profileID, default: 1.0]
@@ -98,7 +98,7 @@ actor RuleEngine {
             guard let profile = profileIndex[profileID],
                   score >= profile.confidenceThreshold else {
                 let name = profileIndex[profileID]?.name ?? profileID.uuidString
-                log("[RuleEngine] profile '\(name)' — confidence \(1.0 - unc) below threshold \(profileIndex[profileID]?.confidenceThreshold ?? -1), not activating")
+                logDebug("[RuleEngine] profile '\(name)' — confidence \(1.0 - unc) below threshold \(profileIndex[profileID]?.confidenceThreshold ?? -1), not activating", CPLogger.rules)
                 return nil
             }
             return ActiveProfile(profile: profile, confidence: score)

--- a/Sources/ControlPlaneApp/RuleStore.swift
+++ b/Sources/ControlPlaneApp/RuleStore.swift
@@ -38,7 +38,7 @@ actor RuleStore {
         try await db.dbQueue.write { db in
             try record.insert(db)
         }
-        log("Rule created: \(rule.id) \"\(rule.name)\"")
+        log("Rule created: \(rule.id) \"\(rule.name)\"", CPLogger.rules)
         return rule
     }
 
@@ -83,7 +83,7 @@ actor RuleStore {
         try await db.dbQueue.write { db in
             try record.update(db)
         }
-        log("Rule updated: \(id) \"\(updated.name)\"")
+        log("Rule updated: \(id) \"\(updated.name)\"", CPLogger.rules)
         return updated
     }
 
@@ -94,7 +94,7 @@ actor RuleStore {
             }
             try RuleRecord.deleteOne(db, key: id.uuidString)
         }
-        log("Rule deleted: \(id)")
+        log("Rule deleted: \(id)", CPLogger.rules)
     }
 
     func list() async throws -> [Rule] {

--- a/Sources/ControlPlaneApp/SensorConfigStore.swift
+++ b/Sources/ControlPlaneApp/SensorConfigStore.swift
@@ -29,7 +29,7 @@ actor SensorConfigStore {
                [String: [String: SensorOptionValue]].self, from: raw
            ) {
             data = parsed
-            log("Sensor config loaded from \(url.path)")
+            log("Sensor config loaded from \(url.path)", CPLogger.setup)
         } else {
             data = [:]
         }
@@ -55,7 +55,7 @@ actor SensorConfigStore {
             let raw = try encoder.encode(data)
             try raw.write(to: fileURL, options: .atomic)
         } catch {
-            log("Failed to save sensor config: \(error.localizedDescription)")
+            logError("Failed to save sensor config: \(error.localizedDescription)", CPLogger.setup)
         }
     }
 }

--- a/Sources/ControlPlaneApp/SensorCoordinator.swift
+++ b/Sources/ControlPlaneApp/SensorCoordinator.swift
@@ -38,7 +38,7 @@ actor SensorCoordinator {
 
         sensors[id] = sensor
         await sensor.start()
-        log("Started sensor: \(id)")
+        log("Started sensor: \(id)", CPLogger.sensors)
     }
 
     /// Current snapshots from every sensor, sorted by sensor ID.
@@ -67,11 +67,11 @@ actor SensorCoordinator {
     /// at the RuleEngine actor, leaving the profile incorrectly deactivated.
     func triggerSnapshotCallback() async {
         guard let onChange = onSnapshotsUpdated else {
-            log("[SensorCoordinator] triggerSnapshotCallback — onSnapshotsUpdated is nil, skipping")
+            logDebug("[SensorCoordinator] triggerSnapshotCallback — onSnapshotsUpdated is nil, skipping", CPLogger.sensors)
             return
         }
         let snapshots = await allSnapshots()
-        log("[SensorCoordinator] triggerSnapshotCallback — evaluating with \(snapshots.count) snapshots")
+        logDebug("[SensorCoordinator] triggerSnapshotCallback — evaluating with \(snapshots.count) snapshots", CPLogger.sensors)
         await onChange(snapshots)
     }
 
@@ -80,7 +80,7 @@ actor SensorCoordinator {
         for sensor in sensors.values {
             await sensor.refresh()
         }
-        log("Sensor snapshots refreshed")
+        log("Sensor snapshots refreshed", CPLogger.sensors)
         await triggerSnapshotCallback()
     }
 
@@ -105,7 +105,7 @@ actor SensorCoordinator {
         }
         try configurable.setOption(key: key, value: value)
         await configStore.set(key: key, value: value, for: id)
-        log("Set option \(key)=\(value) on sensor \(id)")
+        log("Set option \(key)=\(value) on sensor \(id)", CPLogger.sensors)
     }
 
     /// Returns the IDs of all loaded sensors that conform to DynamicKeySensor.
@@ -127,6 +127,6 @@ actor SensorCoordinator {
             await sensor.stop()
         }
         sensors.removeAll()
-        log("All sensors stopped")
+        log("All sensors stopped", CPLogger.sensors)
     }
 }

--- a/Sources/ControlPlaneApp/SocketServer.swift
+++ b/Sources/ControlPlaneApp/SocketServer.swift
@@ -23,7 +23,7 @@ final class SocketServer {
 
         serverFd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard serverFd >= 0 else {
-            log("SocketServer: socket() failed (errno \(errno))")
+            logError("SocketServer: socket() failed (errno \(errno))", CPLogger.socket)
             return
         }
 
@@ -44,13 +44,13 @@ final class SocketServer {
             }
         }
         guard bound == 0 else {
-            log("SocketServer: bind() failed (errno \(errno))")
+            logError("SocketServer: bind() failed (errno \(errno))", CPLogger.socket)
             close(serverFd)
             return
         }
 
         listen(serverFd, 10)
-        log("SocketServer: listening at \(socketPath)")
+        log("SocketServer: listening at \(socketPath)", CPLogger.socket)
 
         // Accept loop on a dedicated background thread — accept(2) blocks.
         let capFd = serverFd
@@ -89,7 +89,7 @@ final class SocketServer {
             do {
                 req = try dec.decode(CPRequest.self, from: raw)
             } catch {
-                log("SocketServer: malformed request — \(error)")
+                logError("SocketServer: malformed request — \(error)", CPLogger.socket)
                 break
             }
 
@@ -99,7 +99,7 @@ final class SocketServer {
                 let frame = try frameMessage(response)
                 if !writeAll(fd: clientFd, data: frame) { break }
             } catch {
-                log("SocketServer: failed to encode response — \(error)")
+                logError("SocketServer: failed to encode response — \(error)", CPLogger.socket)
                 break
             }
         }

--- a/Sources/Sensors/Bluetooth/BluetoothSensor.swift
+++ b/Sources/Sensors/Bluetooth/BluetoothSensor.swift
@@ -1,6 +1,9 @@
 import Foundation
 import IOBluetooth
 import ControlPlaneSDK
+import os
+
+private let btLogger = Logger(subsystem: "com.controlplane.app", category: "BluetoothSensor")
 
 /// Sensor that observes Bluetooth hardware state using IOBluetooth.
 ///
@@ -74,7 +77,7 @@ public final class BluetoothSensor: BaseSensor, DynamicKeySensor {
         guard wasMonitoring != nowMonitoring else { return }
 
         if nowMonitoring {
-            print("[BluetoothSensor] rules reference Bluetooth keys — starting poll loop")
+            btLogger.debug("[BluetoothSensor] rules reference Bluetooth keys — starting poll loop")
             pollTask = Task { [weak self] in
                 while !Task.isCancelled {
                     try? await Task.sleep(nanoseconds: 30_000_000_000)
@@ -83,7 +86,7 @@ public final class BluetoothSensor: BaseSensor, DynamicKeySensor {
                 }
             }
         } else {
-            print("[BluetoothSensor] no rules reference Bluetooth keys — stopping poll loop")
+            btLogger.debug("[BluetoothSensor] no rules reference Bluetooth keys — stopping poll loop")
             pollTask?.cancel()
             pollTask = nil
         }

--- a/Sources/Sensors/FilePresence/FilePresenceSensor.swift
+++ b/Sources/Sensors/FilePresence/FilePresenceSensor.swift
@@ -1,5 +1,8 @@
 import Foundation
 import ControlPlaneSDK
+import os
+
+private let fileLogger = Logger(subsystem: "com.controlplane.app", category: "FilePresenceSensor")
 
 /// Sensor that reports whether files exist at paths referenced by rules.
 ///
@@ -140,7 +143,7 @@ public final class FilePresenceSensor: NSObject, SensorPlugin, DynamicKeySensor,
         // the file system from unmounting.
         let fd = open(dir, O_EVTONLY)
         guard fd >= 0 else {
-            print("[FilePresenceSensor] cannot watch directory \(dir): open failed (errno \(errno))")
+            fileLogger.debug("[FilePresenceSensor] cannot watch directory \(dir, privacy: .public): open failed (errno \(errno))")
             return
         }
 
@@ -171,7 +174,7 @@ public final class FilePresenceSensor: NSObject, SensorPlugin, DynamicKeySensor,
         source.resume()
 
         directoryWatches[dir] = (fd: fd, source: source)
-        print("[FilePresenceSensor] watching directory: \(dir)")
+        fileLogger.debug("[FilePresenceSensor] watching directory: \(dir, privacy: .public)")
     }
 
     /// Cancel and remove the watch for `dir`. Must be called on `watchQueue`.
@@ -179,7 +182,7 @@ public final class FilePresenceSensor: NSObject, SensorPlugin, DynamicKeySensor,
         guard let entry = directoryWatches.removeValue(forKey: dir) else { return }
         entry.source.cancel()
         // fd is closed in the cancel handler set up in addWatch.
-        print("[FilePresenceSensor] stopped watching directory: \(dir)")
+        fileLogger.debug("[FilePresenceSensor] stopped watching directory: \(dir, privacy: .public)")
     }
 
     /// Cancel all active watches. Safe to call from any thread.

--- a/Sources/Sensors/MountedVolume/MountedVolumeSensor.swift
+++ b/Sources/Sensors/MountedVolume/MountedVolumeSensor.swift
@@ -1,6 +1,9 @@
 import Foundation
 import AppKit
 import ControlPlaneSDK
+import os
+
+private let volumeLogger = Logger(subsystem: "com.controlplane.app", category: "MountedVolumeSensor")
 
 public final class MountedVolumeSensor: BaseSensor {
 
@@ -21,7 +24,7 @@ public final class MountedVolumeSensor: BaseSensor {
             queue: nil
         ) { [weak self] notification in
             let path = (notification.userInfo?["NSDevicePath"] as? String) ?? "unknown"
-            NSLog("[MountedVolume] didMountNotification — path: %@", path)
+            volumeLogger.info("[MountedVolume] didMountNotification — path: \(path, privacy: .public)")
             DispatchQueue.main.async { self?.refreshSnapshot() }
         }
         unmountObserver = NSWorkspace.shared.notificationCenter.addObserver(
@@ -30,7 +33,7 @@ public final class MountedVolumeSensor: BaseSensor {
             queue: nil
         ) { [weak self] notification in
             let path = (notification.userInfo?["NSDevicePath"] as? String) ?? "unknown"
-            NSLog("[MountedVolume] didUnmountNotification — path: %@", path)
+            volumeLogger.info("[MountedVolume] didUnmountNotification — path: \(path, privacy: .public)")
             DispatchQueue.main.async { self?.refreshSnapshot() }
         }
         DispatchQueue.main.sync { refreshSnapshot() }
@@ -54,7 +57,7 @@ public final class MountedVolumeSensor: BaseSensor {
             options: []
         ) ?? []
         let names = urls.map { $0.lastPathComponent }
-        NSLog("[MountedVolume] refreshSnapshot — volumes: %@", names.joined(separator: ", "))
+        volumeLogger.info("[MountedVolume] refreshSnapshot — volumes: \(names.joined(separator: ", "), privacy: .public)")
         var readings: [SensorReading] = [
             SensorReading(key: "mounted", label: "Mounted Volumes", value: .strings(names))
         ]

--- a/Sources/Sensors/WiFi/WiFiSensor.swift
+++ b/Sources/Sensors/WiFi/WiFiSensor.swift
@@ -2,6 +2,9 @@ import Foundation
 import CoreWLAN
 import CoreLocation
 import ControlPlaneSDK
+import os
+
+private let wifiLogger = Logger(subsystem: "com.controlplane.app", category: "WiFiSensor")
 
 /// Sensor that observes the current Wi-Fi connection state using CoreWLAN.
 ///
@@ -104,18 +107,18 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
 
             switch mgr.authorizationStatus {
             case .authorizedAlways:
-                print("[WiFiSensor] Location: already authorized (always)")
+                wifiLogger.debug("[WiFiSensor] Location: already authorized (always)")
                 // Already authorized — re-fetch interface so CoreWLAN picks up
                 // the auth state and starts returning SSID/BSSID.
                 self.interface = self.client.interface()
                 self.refreshSnapshot()
             case .notDetermined:
-                print("[WiFiSensor] Location: requesting always authorization")
+                wifiLogger.debug("[WiFiSensor] Location: requesting always authorization")
                 mgr.requestAlwaysAuthorization()
             case .denied, .restricted:
-                print("[WiFiSensor] Location: denied/restricted — SSID/BSSID will be empty")
+                wifiLogger.debug("[WiFiSensor] Location: denied/restricted — SSID/BSSID will be empty")
             @unknown default:
-                print("[WiFiSensor] Location: unknown status (\(mgr.authorizationStatus.rawValue))")
+                wifiLogger.debug("[WiFiSensor] Location: unknown status (\(mgr.authorizationStatus.rawValue))")
             }
         }
     }
@@ -154,10 +157,10 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
         scanEnabled = needsScan
 
         if scanEnabled {
-            print("[WiFiSensor] visible_networks referenced by a rule — starting scan loop")
+            wifiLogger.debug("[WiFiSensor] visible_networks referenced by a rule — starting scan loop")
             startScanLoop()
         } else {
-            print("[WiFiSensor] no rules reference visible_networks — stopping scan loop")
+            wifiLogger.debug("[WiFiSensor] no rules reference visible_networks — stopping scan loop")
             scanTask?.cancel()
             scanTask = nil
             // Clear any stale scan results from the snapshot.
@@ -186,7 +189,7 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
             return
         }
 
-        print("[WiFiSensor] starting network scan (connected=\(connected), scanWhileConnected=\(scanWhileConnected))")
+        wifiLogger.debug("[WiFiSensor] starting network scan (connected=\(connected), scanWhileConnected=\(scanWhileConnected))")
         do {
             let networks = try iface.scanForNetworks(withName: nil)
             let sorted = networks
@@ -195,10 +198,10 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
                     return (ssid, n.rssiValue)
                 }
                 .sorted { $0.1 > $1.1 }   // strongest signal first
-            print("[WiFiSensor] scan found \(sorted.count) network(s)")
+            wifiLogger.debug("[WiFiSensor] scan found \(sorted.count) network(s)")
             lock.withLock { _visibleNetworks = sorted }
         } catch {
-            print("[WiFiSensor] scanForNetworks failed: \(error.localizedDescription)")
+            wifiLogger.debug("[WiFiSensor] scanForNetworks failed: \(error.localizedDescription)")
             lock.withLock { _visibleNetworks = [] }
         }
         refreshSnapshot()
@@ -358,7 +361,7 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
 extension WiFiSensor: CLLocationManagerDelegate {
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
-        print("[WiFiSensor] Location authorization changed: \(status.rawValue)")
+        wifiLogger.debug("[WiFiSensor] Location authorization changed: \(status.rawValue)")
         switch status {
         case .authorizedAlways:
             // Re-fetch the interface — CWWiFiClient caches the auth state and
@@ -367,7 +370,7 @@ extension WiFiSensor: CLLocationManagerDelegate {
             refreshSnapshot()
             Task { await self.runScanIfNeeded() }
         case .denied, .restricted:
-            print("[WiFiSensor] Location denied — SSID/BSSID will remain empty")
+            wifiLogger.debug("[WiFiSensor] Location denied — SSID/BSSID will remain empty")
             refreshSnapshot()
         default:
             break


### PR DESCRIPTION
## Summary

- Replaces the `print()`-based global `log()` with Apple Unified Logging (`os.Logger`)
- Eight named categories: General, Sensors, RuleEngine, Profiles, Actions, Plugins, Socket, Setup -- all filterable in Console.app under subsystem `com.controlplane.app`
- Three log helpers: `log()` (info level), `logDebug()` (debug level), `logError()` (always emitted, no level gate)
- Verbose lines (per-rule match results, per-snapshot callbacks) demoted to `logDebug`; error conditions promoted to `logError`
- Sensor modules (separate SPM targets) get their own private `os.Logger` instance since they cannot import `CPLogger`

### General tab in Preferences

New **General** tab (first tab) with:
- Log level dropdown: **Off** (default) / **Info** / **Debug** -- persisted via `@AppStorage`
- Console.app hint text with the subsystem string to filter on
- **Open Console.app** button

## Test plan

- [ ] `make build` compiles cleanly
- [ ] `make run` launches the app
- [ ] Log level set to **Off** -- nothing in terminal
- [ ] Log level set to **Info** -- lifecycle milestones appear (backend start, profile activation, etc.)
- [ ] Log level set to **Debug** -- per-rule evaluation lines visible
- [ ] Open Console.app, filter subsystem `com.controlplane.app` -- all eight categories visible
- [ ] Change log level, quit and relaunch -- level persists

Closes #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
