### PR TITLE
Replace SCNetworkReachability with Bonjour/mDNS presence detection (issue #539)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -194,10 +194,7 @@ let package = Package(
         .target(
             name: "HostAvailabilitySensor",
             dependencies: ["ControlPlaneSDK"],
-            path: "Sources/Sensors/HostAvailability",
-            linkerSettings: [
-                .linkedFramework("SystemConfiguration"),
-            ]
+            path: "Sources/Sensors/HostAvailability"
         ),
 
         // MARK: - Evaluator plugins

--- a/Sources/ControlPlaneApp/CPLogger.swift
+++ b/Sources/ControlPlaneApp/CPLogger.swift
@@ -1,3 +1,4 @@
+import Foundation
 import os
 
 // MARK: - Log Level

--- a/Sources/ControlPlaneApp/CreateRuleView.swift
+++ b/Sources/ControlPlaneApp/CreateRuleView.swift
@@ -87,6 +87,16 @@ struct CreateRuleView: View {
         sensorID == "com.controlplane.sensors.runningapplication"
     }
 
+    private var isBonjourSensor: Bool {
+        sensorID == "com.controlplane.sensors.hostavailability"
+    }
+
+    /// All device names currently discovered by HostAvailabilitySensor, sorted.
+    private var discoveredBonjourDevices: [String] {
+        guard isBonjourSensor else { return [] }
+        return (selectedSnapshot?.readings.map(\.label) ?? []).sorted()
+    }
+
     /// All regular user-facing applications currently running, sorted by display name.
     private var runningUserApps: [(name: String, bundleID: String)] {
         NSWorkspace.shared.runningApplications
@@ -209,6 +219,8 @@ struct CreateRuleView: View {
                     bluetoothDevicePicker
                 } else if isRunningApplication {
                     runningApplicationPicker
+                } else if isBonjourSensor {
+                    bonjourDevicePicker
                 } else if isDynamic {
                     dynamicKeyField
                 } else if let snap = selectedSnapshot {
@@ -300,6 +312,41 @@ struct CreateRuleView: View {
                 .textFieldStyle(.roundedBorder)
         }
         Text("Only running apps appear in the list above. Type a bundle ID directly for apps that are not currently open.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    /// Picker of Bonjour/mDNS devices currently visible on the local network.
+    /// The rule's readingKey is the device's friendly Bonjour name (e.g. "My NAS").
+    @ViewBuilder
+    private var bonjourDevicePicker: some View {
+        let devices = discoveredBonjourDevices
+        if devices.isEmpty {
+            Text("No Bonjour devices found on the network yet")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        } else {
+            Picker("Device", selection: $readingKey) {
+                Text("Choose…").tag("")
+                ForEach(devices, id: \.self) { name in
+                    Text(name).tag(name)
+                }
+            }
+            .onChange(of: readingKey) { _ in
+                resetBelowKey()
+                if !readingKey.isEmpty {
+                    comparandString = "true"
+                    seedOperator()
+                }
+            }
+        }
+
+        // Manual-entry fallback for devices not currently advertising.
+        LabeledContent("Device name") {
+            TextField("My NAS", text: $readingKey)
+                .textFieldStyle(.roundedBorder)
+        }
+        Text("Devices appear when they are advertising Bonjour services (same as Finder's Network sidebar). Enter a name manually for devices not currently on the network.")
             .font(.caption)
             .foregroundStyle(.secondary)
     }
@@ -414,7 +461,7 @@ struct CreateRuleView: View {
         case "com.controlplane.sensors.runningapplication":
             return ("Running", "Not running")
         case "com.controlplane.sensors.hostavailability":
-            return ("Reachable", "Not reachable")
+            return ("Present", "Not present")
         case "com.controlplane.sensors.screenlock":
             return ("Locked", "Unlocked")
         case "com.controlplane.sensors.laptoplid":
@@ -503,7 +550,7 @@ struct CreateRuleView: View {
         case "com.controlplane.sensors.runningapplication":
             return "com.apple.safari"
         case "com.controlplane.sensors.hostavailability":
-            return "server.local"
+            return "My NAS"
         case "com.controlplane.sensors.usb":
             return "vendorID:productID  e.g. 05ac:12a8"
         default:
@@ -518,7 +565,7 @@ struct CreateRuleView: View {
         case "com.controlplane.sensors.runningapplication":
             return "Bundle identifier of the application (e.g. com.apple.safari)."
         case "com.controlplane.sensors.hostavailability":
-            return "Hostname or IP address to ping."
+            return "Device name as shown in Finder's Network sidebar."
         case "com.controlplane.sensors.usb":
             return "USB vendor and product ID in hex, colon-separated."
         default:

--- a/Sources/Sensors/HostAvailability/HostAvailabilitySensor.swift
+++ b/Sources/Sensors/HostAvailability/HostAvailabilitySensor.swift
@@ -1,68 +1,143 @@
 import Foundation
-import SystemConfiguration
 import ControlPlaneSDK
+import os
 
+private let haLogger = Logger(subsystem: "com.controlplane.app", category: "HostAvailabilitySensor")
+
+/// Sensor that detects whether local-network devices are present by browsing
+/// Bonjour/mDNS service advertisements — the same mechanism that causes devices
+/// to appear in Finder's Network sidebar.
+///
+/// A device is considered "present" (reading = true) when it is advertising at
+/// least one of the browsed service types. The reading key and display label are
+/// the device's friendly Bonjour name (e.g. "My NAS", "Dustin's MacBook Pro").
+///
+/// Because detection is event-driven (NetServiceBrowser callbacks), there is no
+/// polling and no TCP probing. Discovery begins in start() and updates are pushed
+/// to the rule engine via onSnapshotChanged whenever a device appears or disappears.
 public final class HostAvailabilitySensor: BaseSensor, DynamicKeySensor {
 
     public override var pluginIdentifier: String  { "com.controlplane.sensors.hostavailability" }
     public override var pluginDisplayName: String { "Host Availability" }
 
-    private var reachabilityRefs: [String: SCNetworkReachability] = [:]
+    // Service types to browse — covers the broadest set of Finder-visible devices.
+    private let serviceTypes = [
+        "_smb._tcp",          // NAS appliances, Windows shares, most file servers
+        "_afpovertcp._tcp",   // Apple File Protocol (older Macs, NAS)
+        "_device-info._tcp",  // Most Apple devices
+        "_workstation._tcp",  // macOS workstations via mDNSResponder
+        "_ssh._tcp",          // Linux servers, Raspberry Pi, etc.
+    ]
+
+    // One browser per service type — all run on RunLoop.main.
+    private var browsers: [String: NetServiceBrowser] = [:]
+
+    // Discovered device names keyed by service type, under lock.
+    private let lock = NSLock()
+    private var discovered: [String: Set<String>] = [:]   // serviceType → device names
+    private var monitoredKeys: Set<String> = []
 
     public override required init() {
         super.init()
     }
 
+    // MARK: - SensorPlugin
+
     public override func start() async {
-        // Keys are pushed via setMonitoredKeys before or after start; refresh current state.
-        refreshSnapshot()
+        haLogger.info("HostAvailabilitySensor starting — browsing \(self.serviceTypes.count) service types")
+        await MainActor.run {
+            for type_ in serviceTypes {
+                let browser = NetServiceBrowser()
+                browser.delegate = self
+                browser.searchForServices(ofType: type_, inDomain: "local.")
+                browsers[type_] = browser
+            }
+        }
+        publishSnapshot()
     }
 
     public override func stop() async {
-        for (_, ref) in reachabilityRefs {
-            SCNetworkReachabilityUnscheduleFromRunLoop(ref, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
+        await MainActor.run {
+            for browser in browsers.values { browser.stop() }
+            browsers.removeAll()
         }
-        reachabilityRefs.removeAll()
+        lock.withLock {
+            discovered.removeAll()
+            monitoredKeys.removeAll()
+        }
         publishInactive()
+        haLogger.info("HostAvailabilitySensor stopped")
     }
 
+    // MARK: - DynamicKeySensor
+
+    /// Called by the backend after each rule change with the set of device names
+    /// referenced by enabled rules. Only affects which names are reported as
+    /// monitored — browsing continues for all service types regardless.
     public func setMonitoredKeys(_ keys: [String]) {
-        let newSet = Set(keys)
-        let oldSet = Set(reachabilityRefs.keys)
-
-        for removed in oldSet.subtracting(newSet) {
-            if let ref = reachabilityRefs[removed] {
-                SCNetworkReachabilityUnscheduleFromRunLoop(ref, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
-            }
-            reachabilityRefs.removeValue(forKey: removed)
-        }
-
-        for added in newSet.subtracting(oldSet) {
-            guard let ref = SCNetworkReachabilityCreateWithName(nil, added) else { continue }
-            var ctx = SCNetworkReachabilityContext(
-                version: 0,
-                info: Unmanaged.passUnretained(self).toOpaque(),
-                retain: nil,
-                release: nil,
-                copyDescription: nil
-            )
-            SCNetworkReachabilitySetCallback(ref, { _, _, info in
-                guard let info else { return }
-                Unmanaged<HostAvailabilitySensor>.fromOpaque(info).takeUnretainedValue().refreshSnapshot()
-            }, &ctx)
-            SCNetworkReachabilityScheduleWithRunLoop(ref, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
-            reachabilityRefs[added] = ref
-        }
-        refreshSnapshot()
+        lock.withLock { monitoredKeys = Set(keys) }
+        publishSnapshot()
     }
 
-    private func refreshSnapshot() {
-        let readings = reachabilityRefs.map { hostname, ref -> SensorReading in
-            var flags: SCNetworkReachabilityFlags = []
-            SCNetworkReachabilityGetFlags(ref, &flags)
-            let reachable = flags.contains(.reachable) && !flags.contains(.connectionRequired)
-            return SensorReading(key: hostname, label: hostname, value: .boolean(reachable))
+    // MARK: - Snapshot
+
+    private func publishSnapshot() {
+        let (allPresent, monitored) = lock.withLock {
+            let present = discovered.values.reduce(into: Set<String>()) { $0.formUnion($1) }
+            return (present, monitoredKeys)
         }
+
+        var readings: [SensorReading] = []
+
+        // Emit a reading for every currently-present device (powers the UI picker).
+        for name in allPresent.sorted() {
+            readings.append(SensorReading(key: name, label: name, value: .boolean(true)))
+        }
+
+        // For monitored keys that are NOT present, emit false so the rule engine
+        // sees the correct state even when the device is offline.
+        for name in monitored where !allPresent.contains(name) {
+            readings.append(SensorReading(key: name, label: name, value: .boolean(false)))
+        }
+
         publishSnapshot(readings: readings)
+    }
+}
+
+// MARK: - NetServiceBrowserDelegate
+
+extension HostAvailabilitySensor: NetServiceBrowserDelegate {
+
+    public func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didFind service: NetService,
+        moreComing: Bool
+    ) {
+        // Find which service type this browser is responsible for.
+        guard let type_ = browsers.first(where: { $0.value === browser })?.key else { return }
+        let name = service.name
+        haLogger.debug("[\(type_, privacy: .public)] found: \(name, privacy: .public)")
+        lock.withLock { discovered[type_, default: []].insert(name) }
+        if !moreComing { publishSnapshot() }
+    }
+
+    public func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didRemove service: NetService,
+        moreComing: Bool
+    ) {
+        guard let type_ = browsers.first(where: { $0.value === browser })?.key else { return }
+        let name = service.name
+        haLogger.debug("[\(type_, privacy: .public)] removed: \(name, privacy: .public)")
+        lock.withLock { discovered[type_]?.remove(name) }
+        if !moreComing { publishSnapshot() }
+    }
+
+    public func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didNotSearch errorDict: [String: NSNumber]
+    ) {
+        let type_ = browsers.first(where: { $0.value === browser })?.key ?? "?"
+        haLogger.error("[\(type_, privacy: .public)] search error: \(errorDict, privacy: .public)")
     }
 }

--- a/Sources/Sensors/WiFi/WiFiSensor.swift
+++ b/Sources/Sensors/WiFi/WiFiSensor.swift
@@ -189,7 +189,7 @@ public final class WiFiSensor: NSObject, SensorPlugin, ConfigurableSensor, PushS
             return
         }
 
-        wifiLogger.debug("[WiFiSensor] starting network scan (connected=\(connected), scanWhileConnected=\(scanWhileConnected))")
+        wifiLogger.debug("[WiFiSensor] starting network scan (connected=\(connected), scanWhileConnected=\(self.scanWhileConnected))")
         do {
             let networks = try iface.scanForNetworks(withName: nil)
             let sorted = networks


### PR DESCRIPTION
## Summary

Replaces the unreliable `SCNetworkReachability` check with event-driven Bonjour/mDNS browsing. A host is now considered "available" when it is advertising services on the local network -- the same mechanism that populates Finder's Network sidebar.

**How it works:**
- `NetServiceBrowser` watches five service types simultaneously: `_smb._tcp`, `_afpovertcp._tcp`, `_device-info._tcp`, `_workstation._tcp`, `_ssh._tcp`
- A device is "present" the moment any advertisement appears; "not present" when all advertisements stop
- Fully event-driven -- no polling, no TCP connects, no timeouts

**Rule keys are now friendly Bonjour names** (e.g. "My NAS", "Dustin's MacBook Pro") -- what the user sees in Finder's sidebar. The rule creation UI shows a live-browsed picker of currently visible devices with a manual-entry fallback.

### Changes
- `HostAvailabilitySensor`: full rewrite using `NetServiceBrowser` + delegate
- `Package.swift`: removed `SystemConfiguration` linker setting (no longer needed)
- `CreateRuleView`: new Bonjour device picker; boolean labels updated to Present/Not present

## Test plan

- [ ] `make build` compiles cleanly
- [ ] `make run` launches the app
- [ ] Preferences → Sensors → Host Availability shows discovered local devices in the readings list
- [ ] Create rule: Bonjour picker lists visible devices by friendly name; select one
- [ ] Device on network → rule green checkmark, profile activates
- [ ] Power off / disconnect device → within a few seconds rule turns red ×
- [ ] Manual entry: type a name for a device not currently advertising → rule stays red × until device appears

Closes #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
